### PR TITLE
Use link when "pip install"-ing in docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ dockerflow-compatible already.
 Place a `settings.ini` file in the `/app` directory of the container.
 There's an example production `settings.ini` file in the repository called `settings.production-example.ini`. You can
 copy that one, then consult the [configuration documentation below](#configuration-reference) for additional details.
+Finally, set an environment variable called `PHABRICATOR_EMAILS_SETTINGS_PATH` to `/app/settings.ini`.
 
 ### Amazon credentials
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,14 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import os
 
 from alembic import context
 from phabricatoremails import models
-from phabricatoremails.settings import Settings
+from phabricatoremails.settings import Settings, SETTINGS_PATH_ENV_KEY
 from sqlalchemy import create_engine
 
 target_metadata = models.Base.metadata
-settings = Settings.load()
+settings = Settings.load(os.environ.get(SETTINGS_PATH_ENV_KEY))
 db_url = settings.db_url
 
 

--- a/phabricatoremails/cli.py
+++ b/phabricatoremails/cli.py
@@ -3,12 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+import os
 
 import sentry_sdk
 from phabricatoremails.prepare import prepare
 from phabricatoremails.migrate import migrate
 from phabricatoremails.service import service
-from phabricatoremails.settings import Settings
+from phabricatoremails.settings import Settings, SETTINGS_PATH_ENV_KEY
 from statsd import StatsClient
 
 
@@ -32,7 +33,7 @@ def parse_command():
 
 def cli():
     args = parse_command()
-    settings = Settings.load()
+    settings = Settings.load(os.environ.get(SETTINGS_PATH_ENV_KEY))
     if settings.sentry_dsn:
         sentry_sdk.init(settings.sentry_dsn)
 

--- a/phabricatoremails/settings.py
+++ b/phabricatoremails/settings.py
@@ -19,6 +19,9 @@ from phabricatoremails.source import FileSource, PhabricatorSource
 from sqlalchemy import create_engine
 
 
+SETTINGS_PATH_ENV_KEY = "PHABRICATOR_EMAILS_SETTINGS_PATH"
+
+
 def _parse_logger(config: ConfigParser):
     """Provides a logger set up according to our configuration.
 
@@ -120,15 +123,18 @@ class Settings:
         return _parse_mail(self._config, self.logger)
 
     @classmethod
-    def load(cls):
-        """Load and parse settings from a settings.ini file in the package directory."""
+    def load(cls, settings_path=None):
+        """Load and parse settings from a settings.ini.
+
+        Looks in the package directory by default, but will use a custom path if
+        provided.
+        """
 
         config = configparser.ConfigParser()
-        # The location of "settings.ini" cannot be parameterized because alembic
-        # needs access to the db connection string, but can't have access to
-        # CLI parameters. So, our most usable option is to require that "settings.ini"
-        # is in the package directory.
-        path = pathlib.Path(PACKAGE_DIRECTORY / "settings.ini").resolve()
+        if settings_path:
+            path = settings_path
+        else:
+            path = pathlib.Path(PACKAGE_DIRECTORY / "settings.ini").resolve()
         if not config.read(str(path)):
             raise Exception(f'No config file found at "{path}"')
 


### PR DESCRIPTION
`ckolos` ran into the following error when running the docker container:
```
Exception: No config file found at "/app/.local/lib/python3.8/site-packages/settings.ini"
```

This is because we were `pip install`-ing the entire package into the pip `site-packages`.
We only want to `pip install` _enough_ so that we have a convenient binary that we can invoke. However, we still want all the code to remain in `/app`.

By using the `-e` flag in `pip install`, we have pip generate a binary, but that binary just points back into our source in `/app`.