### PR TITLE
Replace placeholder "email preferences" link in email footers

### DIFF
--- a/phabricatoremails/render/template.py
+++ b/phabricatoremails/render/template.py
@@ -203,7 +203,12 @@ class TemplateStore:
     """
 
     def __init__(
-        self, css_text: str, keep_css_classes: bool, html_loader=None, text_loader=None
+        self,
+        phabricator_host: str,
+        css_text: str,
+        keep_css_classes: bool,
+        html_loader=None,
+        text_loader=None,
     ):
         self._css_inline = Premailer(
             css_text=css_text,
@@ -218,12 +223,14 @@ class TemplateStore:
         self.html_jinja_env = _jinja_html(
             html_loader
             if html_loader
-            else jinja2.PackageLoader("phabricatoremails", "render/templates/html")
+            else jinja2.PackageLoader("phabricatoremails", "render/templates/html"),
+            phabricator_host,
         )
         self.text_jinja_env = _jinja_text(
             text_loader
             if text_loader
-            else jinja2.PackageLoader("phabricatoremails", "render/templates/text")
+            else jinja2.PackageLoader("phabricatoremails", "render/templates/text"),
+            phabricator_host,
         )
 
     def get(self, template_path: str) -> Template:
@@ -237,7 +244,7 @@ class TemplateStore:
         )
 
 
-def _jinja_html(loader):
+def _jinja_html(loader, phabricator_host: str):
     jinja_env = jinja2.Environment(
         loader=loader,
         autoescape=True,
@@ -267,10 +274,11 @@ def _jinja_html(loader):
     jinja_env.filters["comment_summary"] = _comment_summary
     jinja_env.filters["secure_comment_summary"] = _secure_comment_summary
     jinja_env.globals["emoji"] = _emoji_html
+    jinja_env.globals["phabricator_host"] = phabricator_host
     return jinja_env
 
 
-def _jinja_text(loader):
+def _jinja_text(loader, phabricator_host: str):
     jinja_env = jinja2.Environment(
         loader=loader,
         autoescape=False,  # These are text emails, we want raw characters
@@ -291,4 +299,5 @@ def _jinja_text(loader):
     jinja_env.filters["file_change"] = _file_change
     jinja_env.filters["comment_summary"] = _comment_summary
     jinja_env.filters["secure_comment_summary"] = _secure_comment_summary
+    jinja_env.globals["phabricator_host"] = phabricator_host
     return jinja_env

--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -235,10 +235,11 @@
     </div>
 {% endmacro %}
 
-{% macro footer(unique_number) %}
+{% macro footer(actor_name, unique_number) %}
     <span class="prevent-fold">{{ unique_number }}</span>
     <div class="footer">
-        <a href="unsub">Email preferences</a>. Feedback/issues/comments for this email are very welcome, please
+        <a href="{{ phabricator_host }}/settings/user/{{ actor_name }}/page/emaildelivery/">Email preferences</a>.
+        Feedback/issues/comments for this email are very welcome, please
         <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Conduit&component=Phabricator">report them on
             Bugzilla</a>
     </div>

--- a/phabricatoremails/render/templates/html/public/abandoned.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/abandoned.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/accepted-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/accepted-as-author.html.jinja2
@@ -35,5 +35,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/accepted-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/accepted-as-reviewer.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/added-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/added-as-reviewer.html.jinja2
@@ -20,5 +20,5 @@
         {{ macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/commented.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/commented.html.jinja2
@@ -24,5 +24,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/created.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/created.html.jinja2
@@ -17,5 +17,5 @@
     {{ macros.reviewers_status(event.reviewers) }}
     {{ macros.affected_files(event.affected_files) }}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/edited-metadata.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/edited-metadata.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/landed.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/pinged.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/pinged.html.jinja2
@@ -24,5 +24,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/removed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/removed-as-reviewer.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/requested-changes-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-changes-as-author.html.jinja2
@@ -27,5 +27,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/requested-changes-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-changes-as-reviewer.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/requested-review.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-review.html.jinja2
@@ -29,5 +29,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/updated.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/updated.html.jinja2
@@ -27,5 +27,5 @@
     {{ macros.reviewers_status(event.reviewers) }}
     {{ macros.affected_files(event.affected_files) }}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/abandoned.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/abandoned.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/accepted-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/accepted-as-author.html.jinja2
@@ -27,5 +27,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/accepted-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/accepted-as-reviewer.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/added-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/added-as-reviewer.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/commented.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/commented.html.jinja2
@@ -18,5 +18,5 @@
         <a href="{{ event.transaction_link }}">View comments</a>
     </div>
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/created.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/created.html.jinja2
@@ -15,5 +15,5 @@
     </div>
 
     {{ macros.reviewers_status(event.reviewers) }}
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/edited-metadata.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/edited-metadata.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/landed.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/pinged.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/pinged.html.jinja2
@@ -19,5 +19,5 @@
         <a href="{{ event.transaction_link }}">View comments</a>
     </div>
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/removed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/removed-as-reviewer.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/requested-changes-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-changes-as-author.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/requested-changes-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-changes-as-reviewer.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/requested-review.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-review.html.jinja2
@@ -21,5 +21,5 @@
 
     {{ macros.reviewers_status(event.reviewers) }}
 
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/updated.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/updated.html.jinja2
@@ -24,5 +24,5 @@
     </div>
     {{ macros.new_changes_link(event.new_changes_link) }}
     {{ macros.reviewers_status(event.reviewers) }}
-    {{ macros.footer(unique_number) }}
+    {{ macros.footer(actor_name, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/text/_macros.text.jinja2
+++ b/phabricatoremails/render/templates/text/_macros.text.jinja2
@@ -24,15 +24,16 @@
 {%- endif %}
 {%- endmacro %}
 
-{% macro footer() %}
+{% macro footer(actor_name) %}
 {# This line is to visually separate the body of the email from the footer contents.
    The length of this line was chosen arbitrarily based on visual appeal. #}
 -------------------------------
 
 Email preferences:
-https://phabricator.services.mozilla.com/preferences/this-link-is-fake
+{{ phabricator_host }}/settings/user/{{ actor_name }}/page/emaildelivery/
 Feedback/issues/comments for this email are very welcome, please report
-them on Bugzilla: https://bugzilla.mozilla.org/fake-link-again
+them on Bugzilla:
+https://bugzilla.mozilla.org/enter_bug.cgi?product=Conduit&component=Phabricator
 {%- endmacro %}
 
 {% macro main_comment(raw_comment) %}

--- a/phabricatoremails/render/templates/text/public/abandoned.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/abandoned.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/accepted-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/accepted-as-author.text.jinja2
@@ -9,4 +9,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/accepted-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/accepted-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/added-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/added-as-reviewer.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/commented.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/commented.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/created.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/created.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.affected_files(event.affected_files) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/edited-metadata.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/edited-metadata.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/landed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/landed.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/pinged.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/pinged.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.main_comment(event.pinged_main_comment) }}
 {{- macros.inline_comments(event.pinged_inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/reclaimed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/reclaimed.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/removed-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/removed-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/requested-changes-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/requested-changes-as-author.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/requested-changes-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/requested-changes-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/requested-review.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/requested-review.text.jinja2
@@ -8,4 +8,4 @@
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/public/updated.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/updated.text.jinja2
@@ -14,4 +14,4 @@ Changes since last update:
 
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.affected_files(event.affected_files) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/abandoned.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/abandoned.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} abandoned this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/accepted-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/accepted-as-author.text.jinja2
@@ -7,4 +7,4 @@
 [!] You can now land this revision.
 {%- endif %}
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/accepted-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/accepted-as-reviewer.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} accepted this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/added-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/added-as-reviewer.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/commented.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/commented.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} commented on this revision.
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/created.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/created.text.jinja2
@@ -6,4 +6,4 @@
 {{- macros.reviewer_action(reviewer, revision) }}
 
 {{- macros.reviewers_status(event.reviewers) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/edited-metadata.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/edited-metadata.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/landed.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/landed.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} landed this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/pinged.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/pinged.text.jinja2
@@ -5,4 +5,4 @@
 {{ actor_name }} mentioned you.
 [!] You should respond to these comments
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/reclaimed.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/reclaimed.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} reclaimed this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/removed-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/removed-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/requested-changes-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/requested-changes-as-author.text.jinja2
@@ -5,4 +5,4 @@
 {{ actor_name }} requested changes {{- event | secure_comment_summary }}.
 [!] You need to update your revision to land it
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/requested-changes-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/requested-changes-as-reviewer.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} requested changes {{- event | secure_comment_summary }}.
 
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/requested-review.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/requested-review.text.jinja2
@@ -6,4 +6,4 @@
 {{- macros.reviewer_action(reviewer, revision) }}
 
 {{- macros.reviewers_status(event.reviewers) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/render/templates/text/secure/updated.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/updated.text.jinja2
@@ -13,4 +13,4 @@ Changes since last update:
 {{ event.new_changes_link }}
 
 {{- macros.reviewers_status(event.reviewers) }}
-{{- macros.footer() }}
+{{- macros.footer(actor_name) }}

--- a/phabricatoremails/service.py
+++ b/phabricatoremails/service.py
@@ -90,6 +90,7 @@ def service(settings: Settings, stats: StatsClient):
     raw_css_path = PACKAGE_DIRECTORY / "render/templates/html/style.css"
     css_text = raw_css_path.read_text()
     template_store = TemplateStore(
+        settings.phabricator_host,
         css_text,
         # Keep CSS classes when outputting to local files, since that indicates local
         # development/testing

--- a/tests/mock_settings.py
+++ b/tests/mock_settings.py
@@ -12,6 +12,7 @@ class MockSettings:
         source=None,
         worker=None,
         bugzilla_host=None,
+        phabricator_host=None,
         sentry_dsn="",
         db_url="",
         db=None,
@@ -21,6 +22,7 @@ class MockSettings:
         self.source = source
         self.worker = worker
         self.bugzilla_host = bugzilla_host
+        self.phabricator_host = phabricator_host
         self.sentry_dsn = sentry_dsn
         self.db_url = db_url
         self._db = db

--- a/tests/render/test_template.py
+++ b/tests/render/test_template.py
@@ -43,7 +43,7 @@ def test_templates_end_with_newline():
 
 
 def test_integration_templates():
-    template_store = TemplateStore("", False)
+    template_store = TemplateStore("", "", False)
     template = template_store.get(PUBLIC_TEMPLATE_PATH_PREFIX + "pinged")
 
     html, text = template.render(
@@ -67,7 +67,7 @@ def test_integration_templates():
 
 
 def test_template_throws_error_if_invalid_template():
-    template_store = TemplateStore("", False)
+    template_store = TemplateStore("", "", False)
     with pytest.raises(TemplateNotFound):
         template_store.get(PUBLIC_TEMPLATE_PATH_PREFIX + "invalid")
 
@@ -89,6 +89,7 @@ def test_template_is_rendered_with_parameters():
 
 def test_css_is_inlined():
     template_store = TemplateStore(
+        "",
         ".custom-class { display: none }",
         False,
         html_loader=DictLoader(
@@ -115,7 +116,7 @@ def test_html_environment():
         "{{ emoji('airplane') | safe }}"
     )
 
-    jinja_env = _jinja_html(DictLoader({"example.html.jinja2": template}))
+    jinja_env = _jinja_html(DictLoader({"example.html.jinja2": template}), "")
     template = jinja_env.get_template("example.html.jinja2")
     date = datetime.fromtimestamp(10000, timezone.utc)
     html = template.render(
@@ -135,7 +136,7 @@ def test_text_environment():
         "{{ raw_comment | comment }}"
     )
 
-    jinja_env = _jinja_text(DictLoader({"example.text.jinja2": template}))
+    jinja_env = _jinja_text(DictLoader({"example.text.jinja2": template}), "")
     template = jinja_env.get_template("example.text.jinja2")
     text = template.render(
         {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -106,7 +106,7 @@ def test_integration_pipeline():
         }
     )
     mail = MockMail()
-    render = Render(TemplateStore("", False))
+    render = Render(TemplateStore("", "", False))
     logger = logging.create_dev_logger()
     pipeline = Pipeline(source, render, mail, logger, MockStats())
     with spy_on(mail.send), spy_on(source.fetch_next):
@@ -178,7 +178,7 @@ def test_pipeline_skips_events_that_fail_to_render():
         }
     )
     mail = MockMail()
-    render = Render(TemplateStore("", False))
+    render = Render(TemplateStore("", "", False))
     logger = logging.create_dev_logger()
     pipeline = Pipeline(source, render, mail, logger, MockStats())
     with spy_on(mail.send):
@@ -215,7 +215,7 @@ def test_service_reads_css(mock_template_store):
     db = MockDB(is_initialized=True)
     settings = MockSettings(worker=MockWorker(), db=db)
     service(settings, MockStats())
-    assert ".event-content" in mock_template_store.call_args.args[0]
+    assert ".event-content" in mock_template_store.call_args.args[1]
 
 
 @patch("phabricatoremails.service.TemplateStore")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -142,6 +142,9 @@ def test_parse_fs_mail(tmp_path):
 def test_settings():
     config = _config_parser(
         """
+    [phabricator]
+    host=phabricator.host
+
     [dev]
     file=example.json
 
@@ -153,6 +156,7 @@ def test_settings():
     """
     )
     settings = Settings(config)
+    assert settings.phabricator_host == "phabricator.host"
     assert settings.bugzilla_host == "bugzilla.host"
 
 


### PR DESCRIPTION
[This](https://github.com/mozilla-conduit/phabricator-emails/compare/replace-footer-placeholder-link?expand=1#diff-5bb0602e99a2bf20205383327fc9f548L241) is the meat of the change - the "email preferences" URL was a placeholder :)