### PR TITLE
Bug 1654340: Use recipient's username for prefs link

### DIFF
--- a/phabricatoremails/render/events/common.py
+++ b/phabricatoremails/render/events/common.py
@@ -17,6 +17,7 @@ Additional information about this module can be found in __init__.py
 @dataclass
 class Recipient:
     email: str
+    username: str
     timezone: timezone
     is_actor: bool
 
@@ -31,6 +32,7 @@ class Recipient:
             minutes = ceil((offset_seconds - hours * 3600) / 60)
         return cls(
             recipient["email"],
+            recipient["username"],
             timezone(timedelta(hours=hours, minutes=minutes)),
             recipient["isActor"],
         )

--- a/phabricatoremails/render/mailbatch.py
+++ b/phabricatoremails/render/mailbatch.py
@@ -22,6 +22,7 @@ class Target:
 
     template_path: str
     recipient_email: str
+    recipient_username: str
     kwargs: Dict
 
 
@@ -53,7 +54,9 @@ class MailBatch:
             return
 
         kwargs["recipient_timezone"] = recipient.timezone
-        self._targets[recipient.email] = Target(template_path, recipient.email, kwargs)
+        self._targets[recipient.email] = Target(
+            template_path, recipient.email, recipient.username, kwargs
+        )
 
     def target_many(self, recipients: List[Recipient], template_path: str, **kwargs):
         """Appends many emails to be sent for the current event.
@@ -104,6 +107,7 @@ class MailBatch:
                 template_params={
                     "revision": revision,
                     "actor_name": actor_name,
+                    "recipient_username": target.recipient_username,
                     "unique_number": unique_number,
                     "event": event,
                     **target.kwargs,
@@ -133,6 +137,7 @@ class MailBatch:
                 template_params={
                     "revision": revision,
                     "actor_name": actor_name,
+                    "recipient_username": target.recipient_username,
                     "unique_number": unique_number,
                     "event": event,
                     **target.kwargs,

--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -235,10 +235,10 @@
     </div>
 {% endmacro %}
 
-{% macro footer(actor_name, unique_number) %}
+{% macro footer(recipient_username, unique_number) %}
     <span class="prevent-fold">{{ unique_number }}</span>
     <div class="footer">
-        <a href="{{ phabricator_host }}/settings/user/{{ actor_name }}/page/emaildelivery/">Email preferences</a>.
+        <a href="{{ phabricator_host }}/settings/user/{{ recipient_username }}/page/emaildelivery/">Email preferences</a>.
         Feedback/issues/comments for this email are very welcome, please
         <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Conduit&component=Phabricator">report them on
             Bugzilla</a>

--- a/phabricatoremails/render/templates/html/public/abandoned.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/abandoned.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/accepted-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/accepted-as-author.html.jinja2
@@ -35,5 +35,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/accepted-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/accepted-as-reviewer.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/added-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/added-as-reviewer.html.jinja2
@@ -20,5 +20,5 @@
         {{ macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/commented.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/commented.html.jinja2
@@ -24,5 +24,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/created.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/created.html.jinja2
@@ -17,5 +17,5 @@
     {{ macros.reviewers_status(event.reviewers) }}
     {{ macros.affected_files(event.affected_files) }}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/edited-metadata.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/edited-metadata.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/landed.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/pinged.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/pinged.html.jinja2
@@ -24,5 +24,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/removed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/removed-as-reviewer.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/requested-changes-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-changes-as-author.html.jinja2
@@ -27,5 +27,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/requested-changes-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-changes-as-reviewer.html.jinja2
@@ -26,5 +26,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/requested-review.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-review.html.jinja2
@@ -29,5 +29,5 @@
         {{ macros.inline_comment(comment, recipient_timezone) }}
     {% endfor %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/public/updated.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/updated.html.jinja2
@@ -27,5 +27,5 @@
     {{ macros.reviewers_status(event.reviewers) }}
     {{ macros.affected_files(event.affected_files) }}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/abandoned.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/abandoned.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/accepted-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/accepted-as-author.html.jinja2
@@ -27,5 +27,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/accepted-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/accepted-as-reviewer.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/added-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/added-as-reviewer.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/commented.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/commented.html.jinja2
@@ -18,5 +18,5 @@
         <a href="{{ event.transaction_link }}">View comments</a>
     </div>
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/created.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/created.html.jinja2
@@ -15,5 +15,5 @@
     </div>
 
     {{ macros.reviewers_status(event.reviewers) }}
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/edited-metadata.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/edited-metadata.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/landed.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/pinged.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/pinged.html.jinja2
@@ -19,5 +19,5 @@
         <a href="{{ event.transaction_link }}">View comments</a>
     </div>
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/removed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/removed-as-reviewer.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/requested-changes-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-changes-as-author.html.jinja2
@@ -19,5 +19,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/requested-changes-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-changes-as-reviewer.html.jinja2
@@ -18,5 +18,5 @@
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/requested-review.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-review.html.jinja2
@@ -21,5 +21,5 @@
 
     {{ macros.reviewers_status(event.reviewers) }}
 
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/updated.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/updated.html.jinja2
@@ -24,5 +24,5 @@
     </div>
     {{ macros.new_changes_link(event.new_changes_link) }}
     {{ macros.reviewers_status(event.reviewers) }}
-    {{ macros.footer(actor_name, unique_number) }}
+    {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/text/_macros.text.jinja2
+++ b/phabricatoremails/render/templates/text/_macros.text.jinja2
@@ -24,13 +24,13 @@
 {%- endif %}
 {%- endmacro %}
 
-{% macro footer(actor_name) %}
+{% macro footer(recipient_username) %}
 {# This line is to visually separate the body of the email from the footer contents.
    The length of this line was chosen arbitrarily based on visual appeal. #}
 -------------------------------
 
 Email preferences:
-{{ phabricator_host }}/settings/user/{{ actor_name }}/page/emaildelivery/
+{{ phabricator_host }}/settings/user/{{ recipient_username }}/page/emaildelivery/
 Feedback/issues/comments for this email are very welcome, please report
 them on Bugzilla:
 https://bugzilla.mozilla.org/enter_bug.cgi?product=Conduit&component=Phabricator

--- a/phabricatoremails/render/templates/text/public/abandoned.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/abandoned.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/accepted-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/accepted-as-author.text.jinja2
@@ -9,4 +9,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/accepted-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/accepted-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/added-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/added-as-reviewer.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/commented.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/commented.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/created.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/created.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.affected_files(event.affected_files) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/edited-metadata.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/edited-metadata.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/landed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/landed.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/pinged.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/pinged.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.main_comment(event.pinged_main_comment) }}
 {{- macros.inline_comments(event.pinged_inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/reclaimed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/reclaimed.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/removed-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/removed-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/requested-changes-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/requested-changes-as-author.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/requested-changes-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/requested-changes-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/requested-review.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/requested-review.text.jinja2
@@ -8,4 +8,4 @@
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.main_comment(event.main_comment) }}
 {{- macros.inline_comments(event.inline_comments) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/updated.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/updated.text.jinja2
@@ -14,4 +14,4 @@ Changes since last update:
 
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.affected_files(event.affected_files) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/abandoned.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/abandoned.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} abandoned this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/accepted-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/accepted-as-author.text.jinja2
@@ -7,4 +7,4 @@
 [!] You can now land this revision.
 {%- endif %}
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/accepted-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/accepted-as-reviewer.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} accepted this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/added-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/added-as-reviewer.text.jinja2
@@ -7,4 +7,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/commented.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/commented.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} commented on this revision.
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/created.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/created.text.jinja2
@@ -6,4 +6,4 @@
 {{- macros.reviewer_action(reviewer, revision) }}
 
 {{- macros.reviewers_status(event.reviewers) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/edited-metadata.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/edited-metadata.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_status(event.reviewers) }}
 {{- macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/landed.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/landed.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} landed this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/pinged.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/pinged.text.jinja2
@@ -5,4 +5,4 @@
 {{ actor_name }} mentioned you.
 [!] You should respond to these comments
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/reclaimed.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/reclaimed.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} reclaimed this revision {{- event | secure_comment_summary }}.
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/removed-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/removed-as-reviewer.text.jinja2
@@ -6,4 +6,4 @@
 
 {{- macros.reviewers_with_changes(event.reviewers) }}
 {{- macros.secure_metadata_changes(event.is_title_changed, event.is_bug_changed, revision) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/requested-changes-as-author.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/requested-changes-as-author.text.jinja2
@@ -5,4 +5,4 @@
 {{ actor_name }} requested changes {{- event | secure_comment_summary }}.
 [!] You need to update your revision to land it
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/requested-changes-as-reviewer.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/requested-changes-as-reviewer.text.jinja2
@@ -4,4 +4,4 @@
 
 {{ actor_name }} requested changes {{- event | secure_comment_summary }}.
 
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/requested-review.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/requested-review.text.jinja2
@@ -6,4 +6,4 @@
 {{- macros.reviewer_action(reviewer, revision) }}
 
 {{- macros.reviewers_status(event.reviewers) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/updated.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/updated.text.jinja2
@@ -13,4 +13,4 @@ Changes since last update:
 {{ event.new_changes_link }}
 
 {{- macros.reviewers_status(event.reviewers) }}
-{{- macros.footer(actor_name) }}
+{{- macros.footer(recipient_username) }}

--- a/tests/render/test_mailbatch.py
+++ b/tests/render/test_mailbatch.py
@@ -14,15 +14,15 @@ from phabricatoremails.render.mailbatch import (
 )
 from tests.render.mock_template import MockTemplateStore
 
-NON_ACTOR_RECIPIENT = Recipient("1@mail", timezone.utc, False)
+NON_ACTOR_RECIPIENT = Recipient("1@mail", "1", timezone.utc, False)
 PUBLIC_REVISION = Revision(1, "revision", "link", None)
 EVENT = RevisionCreated([], [])
 
 
 def test_target():
     batch = MailBatch(MockTemplateStore())
-    batch.target(Recipient("1@mail", timezone.utc, False), "template-author")
-    batch.target(Recipient("2@mail", timezone.utc, False), "template-reviewer")
+    batch.target(Recipient("1@mail", "1", timezone.utc, False), "template-author")
+    batch.target(Recipient("2@mail", "2", timezone.utc, False), "template-reviewer")
     emails = batch.process(PUBLIC_REVISION, "actor", 0, 0, EVENT)
     assert len(emails) == 2
     assert emails[0].to == "1@mail"
@@ -33,15 +33,15 @@ def test_target_many():
     batch = MailBatch(MockTemplateStore())
     batch.target_many(
         [
-            Recipient("1@mail", timezone.utc, False),
-            Recipient("2@mail", timezone.utc, False),
+            Recipient("1@mail", "1", timezone.utc, False),
+            Recipient("2@mail", "2", timezone.utc, False),
         ],
         "template-reviewer",
     )
     batch.target_many(
         [
-            Recipient("3@mail", timezone.utc, False),
-            Recipient("4@mail", timezone.utc, False),
+            Recipient("3@mail", "3", timezone.utc, False),
+            Recipient("4@mail", "4", timezone.utc, False),
         ],
         "template-reviewer",
     )
@@ -55,11 +55,11 @@ def test_target_many():
 
 def test_adds_targets():
     batch = MailBatch(MockTemplateStore())
-    batch.target(Recipient("1@mail", timezone.utc, False), "template-author")
+    batch.target(Recipient("1@mail", "1", timezone.utc, False), "template-author")
     batch.target_many(
         [
-            Recipient("2@mail", timezone.utc, False),
-            Recipient("3@mail", timezone.utc, False),
+            Recipient("2@mail", "2", timezone.utc, False),
+            Recipient("3@mail", "3", timezone.utc, False),
         ],
         "template-reviewer",
     )
@@ -72,11 +72,11 @@ def test_adds_targets():
 
 def test_only_sends_to_each_recipient_once():
     batch = MailBatch(MockTemplateStore())
-    batch.target(Recipient("1@mail", timezone.utc, False), "template-author")
+    batch.target(Recipient("1@mail", "1", timezone.utc, False), "template-author")
     batch.target_many(
         [
-            Recipient("1@mail", timezone.utc, False),
-            Recipient("2@mail", timezone.utc, False),
+            Recipient("1@mail", "1", timezone.utc, False),
+            Recipient("2@mail", "2", timezone.utc, False),
         ],
         "template-reviewer",
     )
@@ -95,7 +95,7 @@ def test_filter_target_no_recipient():
 
 def test_filter_target_is_actor():
     batch = MailBatch(MockTemplateStore())
-    batch.target(Recipient("1@mail", timezone.utc, True), "template-author")
+    batch.target(Recipient("1@mail", "1", timezone.utc, True), "template-author")
     emails = batch.process(PUBLIC_REVISION, "actor", 0, 0, EVENT)
     assert len(emails) == 0
 

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -17,7 +17,12 @@ BODY = {
             "isActionable": True,
             "status": "requested-changes",
             "recipients": [
-                {"timezoneOffset": -25200, "email": "reviewer@mail", "isActor": False}
+                {
+                    "timezoneOffset": -25200,
+                    "username": "reviewer",
+                    "email": "reviewer@mail",
+                    "isActor": False,
+                }
             ],
         }
     ],

--- a/tests/render/test_template.py
+++ b/tests/render/test_template.py
@@ -50,9 +50,10 @@ def test_integration_templates():
         {
             "revision": Revision(1, "revision", "link", None),
             "actor_name": "actor",
+            "recipient_username": "1",
             "unique_number": 0,
             "event": RevisionCommentPinged(
-                Recipient("1@mail", timezone.utc, False),
+                Recipient("1@mail", "1", timezone.utc, False),
                 "you've been pinged",
                 [],
                 "link",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -46,11 +46,13 @@ def test_integration_pipeline():
                         "body": {
                             "reviewers": [
                                 {
+                                    "username": "2",
                                     "email": "2@mail",
                                     "timezoneOffset": 0,
                                     "isActor": False,
                                 },
                                 {
+                                    "username": "3",
                                     "email": "3@mail",
                                     "timezoneOffset": 0,
                                     "isActor": False,
@@ -73,6 +75,7 @@ def test_integration_pipeline():
                         "body": {
                             "reviewers": [
                                 {
+                                    "username": "5",
                                     "email": "5@mail",
                                     "timezoneOffset": 0,
                                     "isActor": False,


### PR DESCRIPTION
When a user receives an email, links to that user's preferences should be
populated with that user's details.

This patch resolves an issue where the links were being populated with the
actor's details instead.