### PR TITLE
Bug 1667877: Remove unnecessary "secure revision without bug" code

### DIFF
--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -43,12 +43,10 @@
 {% macro secure_title(revision) %}
     <div class="title">
         <a class="revision" href="{{ revision.link }}">D{{ revision.id }}: (secure revision)</a>
-        {% if revision.bug %}
-            <div class="bug">
-                Associated with
-                <a href="{{ revision.bug.link }}">bug {{ revision.bug.id }}: (secure bug)</a>
-            </div>
-        {% endif %}
+        <div class="bug">
+            Associated with
+            <a href="{{ revision.bug.link }}">bug {{ revision.bug.id }}: (secure bug)</a>
+        </div>
     </div>
 {% endmacro %}
 
@@ -207,11 +205,7 @@
                 <tr>
                     <td class="field">Bug changed to:</td>
                     <td class="value">
-                        {% if revision.bug %}
-                            <a href="{{ revision.bug.link }}">{{ revision.bug.id }} (secure bug)</a>
-                        {% else %}
-                            <div class="none">None</div>
-                        {% endif %}
+                        <a href="{{ revision.bug.link }}">{{ revision.bug.id }} (secure bug)</a>
                     </td>
                 </tr>
             {% endif %}

--- a/phabricatoremails/render/templates/text/_macros.text.jinja2
+++ b/phabricatoremails/render/templates/text/_macros.text.jinja2
@@ -9,11 +9,9 @@
 
 {% macro secure_revision_info(revision) %}
 {{- revision.link }}
-{%- if revision.bug %}
 
 (Associated with secure bug {{ revision.bug.id }})
 ({{ revision.bug.link }})
-{%- endif %}
 {%- endmacro %}
 
 {% macro reviewer_action(reviewer, revision) %}
@@ -101,11 +99,7 @@ Metadata changes:
 - Title changed: (see the secure title on Phabricator)
 {%- endif %}
 {%- if is_bug_changed %}
-{%- if revision.bug %}
 - Bug changed to: {{ revision.bug.id }} (secure bug)
-{%- else %}
-- Bug changed to: None
-{%- endif %}
 {%- endif %}
 {%- endmacro %}
 


### PR DESCRIPTION
The only case in which a secure revision would not have a bug is when a
revision is first created and hasn't been processed by "phab-bot" yet.
Since emails shouldn't be submitted for a revision until it's been
checked by "phab-bot", we don't need to worry about this case.

Therefore, the code can be marginally simplified.