### PR TITLE
Bug 1668079: bump apt package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ LABEL community="https://chat.mozilla.org/#/room/#conduit:mozilla.org"
 LABEL bug-component="https://bugzilla.mozilla.org/enter_bug.cgi?product=Conduit&component=Phabricator"
 
 RUN apt-get update && apt-get install -y \
-    postgresql-client=11+200+deb10u3 \
-    libpq-dev=11.7-0+deb10u1 \
+    postgresql-client=11+200+deb10u4 \
+    libpq-dev=11.9-0+deb10u1 \
     gcc=4:8.3.0-1
 
 RUN addgroup --gid 10001 app && adduser -q --gecos "" --disabled-password --uid 10001 --gid 10001 --home /app --shell /bin/sh app


### PR DESCRIPTION
The current libpq-dev version is not installable with the
python:3.8.2-slim version of Ubuntu.