### PR TITLE
Bug 1669272: log if in DEV mode and server encountered error

### DIFF
--- a/phabricatoremails/settings.py
+++ b/phabricatoremails/settings.py
@@ -22,14 +22,14 @@ from sqlalchemy import create_engine
 SETTINGS_PATH_ENV_KEY = "PHABRICATOR_EMAILS_SETTINGS_PATH"
 
 
-def _parse_logger(config: ConfigParser):
+def _parse_logger(is_dev: bool):
     """Provides a logger set up according to our configuration.
 
     The regular logger is noisy and implements the MozLog JSON format, so we also
     have a "dev" logger that simply prints out each log without any annotations.
     The correct logger is chosen based on the provided configuration file.
     """
-    if config.has_section("dev"):
+    if is_dev:
         return create_dev_logger()
     else:
         return create_logger()
@@ -108,10 +108,12 @@ class Settings:
     logger: Logger
     sentry_dsn: str
     db_url: str
+    is_dev: bool
     _config: ConfigParser
 
     def __init__(self, config: ConfigParser):
-        logger = _parse_logger(config)
+        is_dev = config.has_section("dev")
+        logger = _parse_logger(is_dev)
         source, worker = _parse_pipeline(config, logger)
         self.source = source
         self.worker = worker
@@ -120,6 +122,7 @@ class Settings:
         self.logger = logger
         self.sentry_dsn = config.get("sentry", "dsn", fallback="")
         self.db_url = config.get("db", "url")
+        self.is_dev = is_dev
         self._config = config
 
     def db(self):

--- a/tests/mock_settings.py
+++ b/tests/mock_settings.py
@@ -15,8 +15,9 @@ class MockSettings:
         phabricator_host=None,
         sentry_dsn="",
         db_url="",
+        is_dev=False,
         db=None,
-        mail=None
+        mail=None,
     ):
         self.logger = logging.getLogger()
         self.source = source
@@ -25,6 +26,7 @@ class MockSettings:
         self.phabricator_host = phabricator_host
         self.sentry_dsn = sentry_dsn
         self.db_url = db_url
+        self.is_dev = is_dev
         self._db = db
         self._mail = mail
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,22 +28,12 @@ def _config_parser(ini_contents: str):
 
 
 def test_parse_logger():
-    dev_config = _config_parser(
-        """
-    [dev]
-    """
-    )
     with mock.patch("phabricatoremails.settings.create_dev_logger") as create_fn:
-        _parse_logger(dev_config)
+        _parse_logger(True)
         create_fn.assert_called_once()
 
-    prod_config = _config_parser(
-        """
-    [phabricator]
-    """
-    )
     with mock.patch("phabricatoremails.settings.create_logger") as create_fn:
-        _parse_logger(prod_config)
+        _parse_logger(False)
         create_fn.assert_called_once()
 
 


### PR DESCRIPTION
When iterating locally, it can be difficult to diagnose why an email
isn't being generated. Having a simple log to quickly determine whether
the issue is Phabricator-side or phab-email-side is convenient.