### PR TITLE
Bug 1669371: Show reviewer information when revision is reclaimed

### DIFF
--- a/phabricatoremails/render/events/phabricator.py
+++ b/phabricatoremails/render/events/phabricator.py
@@ -202,7 +202,7 @@ class RevisionReclaimed:
     main_comment_message: Optional[CommentMessage]
     inline_comments: List[InlineComment]
     transaction_link: str
-    reviewers: List[Recipient]
+    reviewers: List[Reviewer]
 
     @classmethod
     def parse(cls, body: Dict):
@@ -210,7 +210,7 @@ class RevisionReclaimed:
             CommentMessage.parse_optional(body.get("mainCommentMessage")),
             InlineComment.parse_many(body["inlineComments"]),
             body["transactionLink"],
-            [Recipient.parse(reviewer) for reviewer in body["reviewers"]],
+            [Reviewer.parse(reviewer) for reviewer in body["reviewers"]],
         )
 
 

--- a/phabricatoremails/render/events/phabricator_secure.py
+++ b/phabricatoremails/render/events/phabricator_secure.py
@@ -63,14 +63,14 @@ class SecureRevisionCreated:
 
 @dataclass
 class SecureRevisionReclaimed:
-    reviewers: List[Recipient]
+    reviewers: List[Reviewer]
     comment_count: int
     transaction_link: str
 
     @classmethod
     def parse(cls, body: Dict):
         return cls(
-            [Recipient.parse(reviewer) for reviewer in body["reviewers"]],
+            [Reviewer.parse(reviewer) for reviewer in body["reviewers"]],
             body["commentCount"],
             body["transactionLink"],
         )

--- a/phabricatoremails/render/render.py
+++ b/phabricatoremails/render/render.py
@@ -124,7 +124,9 @@ def parse_body(kind: str, is_secure: bool, raw_body: Dict, batch: MailBatch):
             body = SecureRevisionReclaimed.parse(raw_body)
         else:
             body = RevisionReclaimed.parse(raw_body)
-        batch.target_many(body.reviewers, "reclaimed")
+
+        for reviewer in body.reviewers:
+            batch.target_many(reviewer.recipients, "reclaimed", reviewer=reviewer)
     elif kind == RevisionCreated.KIND:
         if is_secure:
             body = SecureRevisionCreated.parse(raw_body)

--- a/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
@@ -2,21 +2,32 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
-        {{ emoji("loudspeaker") | safe }} {{ actor_name }} reclaimed this revision {{- event | comment_summary }}.
+    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+        {{ emoji("loudspeaker") | safe }}
+        {% if reviewer is accepted_reviewer %}
+            {{ actor_name }} reclaimed this revision that you've accepted {{- event | comment_summary }}.
+        {% else %}
+            {{ actor_name }} reclaimed this revision {{- event | comment_summary }}.
+        {% endif %}
     {% endcall %}
 
     {{ macros.title(revision) }}
 
     <div class="summary">
         <span class="emoji">{{ emoji("loudspeaker") | safe }}</span>
-        <span class="text"><span><span
-                class="actor">{{ actor_name }}</span> reclaimed this revision {{- event | comment_summary }}</span></span>
+        {% if reviewer is accepted_reviewer %}
+            <span class="text"><span><span class="actor">{{ actor_name }}</span> reclaimed this revision that you've accepted {{- event | comment_summary }}</span></span>
+        {% else %}
+            <span class="text"><span><span class="actor">{{ actor_name }}</span> reclaimed this revision {{- event | comment_summary }}</span></span>
+            {{ macros.reviewer_action(reviewer, revision) }}
+        {% endif %}
     </div>
 
     {% if event is commented_on %}
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
+
+    {{ macros.reviewers_status(event.reviewers) }}
 
     {% if event.main_comment_message %}
         {{ macros.main_comment(event.main_comment_message) }}

--- a/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
@@ -2,21 +2,32 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
-        {{ emoji("loudspeaker") | safe }} {{ actor_name }} reclaimed this revision {{- event | secure_comment_summary }}.
+    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+        {{ emoji("loudspeaker") | safe }}
+        {% if reviewer is accepted_reviewer %}
+            {{ actor_name }} reclaimed this revision that you've accepted {{- event | secure_comment_summary }}.
+        {% else %}
+            {{ actor_name }} reclaimed this revision {{- event | secure_comment_summary }}.
+        {% endif %}
     {% endcall %}
 
     {{ macros.secure_title(revision) }}
 
     <div class="summary">
         <span class="emoji">{{ emoji("loudspeaker") | safe }}</span>
-        <span class="text"><span><span
-                class="actor">{{ actor_name }}</span> reclaimed this revision {{- event | secure_comment_summary }}</span></span>
+        {% if reviewer is accepted_reviewer %}
+            <span class="text"><span><span class="actor">{{ actor_name }}</span> reclaimed this revision that you've accepted {{- event | secure_comment_summary }}</span></span>
+        {% else %}
+            <span class="text"><span><span class="actor">{{ actor_name }}</span> reclaimed this revision {{- event | secure_comment_summary }}</span></span>
+            {{ macros.reviewer_action(reviewer, revision) }}
+        {% endif %}
     </div>
 
     {% if event is commented_on_secure %}
         {{ macros.comments_link(event.transaction_link) }}
     {% endif %}
+
+    {{ macros.reviewers_status(event.reviewers) }}
 
     {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/text/public/reclaimed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/reclaimed.text.jinja2
@@ -2,8 +2,14 @@
 
 {{- macros.revision_info(revision) }}
 
-{{ actor_name }} reclaimed this revision {{- event | comment_summary }}.
+{% if reviewer is accepted_reviewer %}
+{{- actor_name }} reclaimed this revision that you've accepted {{- event | comment_summary }}.
+{%- else %}
+{{- actor_name }} reclaimed this revision {{- event | comment_summary }}.
+{{- macros.reviewer_action(reviewer, revision) }}
+{%- endif %}
 
+{{- macros.reviewers_status(event.reviewers) }}
 {{- macros.main_comment(event.main_comment_message) }}
 {{- macros.inline_comments(event.inline_comments) }}
 {{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/reclaimed.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/reclaimed.text.jinja2
@@ -2,6 +2,12 @@
 
 {{- macros.secure_revision_info(revision) }}
 
-{{ actor_name }} reclaimed this revision {{- event | secure_comment_summary }}.
+{% if reviewer is accepted_reviewer %}
+{{- actor_name }} reclaimed this revision that you've accepted {{- event | secure_comment_summary }}.
+{%- else %}
+{{- actor_name }} reclaimed this revision {{- event | secure_comment_summary }}.
+{{- macros.reviewer_action(reviewer, revision) }}
+{%- endif %}
 
+{{- macros.reviewers_status(event.reviewers) }}
 {{- macros.footer(recipient_username) }}

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -47,16 +47,30 @@ def test_integration_pipeline():
                         "body": {
                             "reviewers": [
                                 {
-                                    "username": "2",
-                                    "email": "2@mail",
-                                    "timezoneOffset": 0,
-                                    "isActor": False,
+                                    "name": "2",
+                                    "isActionable": False,
+                                    "status": "accepted",
+                                    "recipients": [
+                                        {
+                                            "timezoneOffset": 0,
+                                            "username": "2",
+                                            "email": "2@mail",
+                                            "isActor": False,
+                                        }
+                                    ],
                                 },
                                 {
-                                    "username": "3",
-                                    "email": "3@mail",
-                                    "timezoneOffset": 0,
-                                    "isActor": False,
+                                    "name": "3",
+                                    "isActionable": True,
+                                    "status": "requested-changes",
+                                    "recipients": [
+                                        {
+                                            "timezoneOffset": 0,
+                                            "username": "3",
+                                            "email": "3@mail",
+                                            "isActor": False,
+                                        }
+                                    ],
                                 },
                             ],
                             "commentCount": 1,
@@ -132,7 +146,7 @@ def test_integration_pipeline():
         emails[0],
         "D1: (secure bug 1)",
         "2@mail",
-        "1 reclaimed this revision and submitted a comment.",
+        "1 reclaimed this revision that you've accepted and submitted a comment.",
     )
     _assert_mail(
         emails[1],


### PR DESCRIPTION
When a revision is reclaimed, it can already be "ready for review".
When this happens, reviewers should be marked actionable and the
reviewer status table visible in the email.