### PR TITLE
Bug 1671259: Suppress "Caught up with Feed" log

### DIFF
--- a/phabricatoremails/settings.py
+++ b/phabricatoremails/settings.py
@@ -41,7 +41,7 @@ def _parse_host(raw_host: str):
     return raw_host
 
 
-def _parse_pipeline(config: ConfigParser, logger: Logger):
+def _parse_pipeline(config: ConfigParser, logger: Logger, is_dev: bool):
     """Provides data-fetching implementations according to our configuration.
 
     To facilitate easier local development, we have a few different combinations of
@@ -65,7 +65,7 @@ def _parse_pipeline(config: ConfigParser, logger: Logger):
         return source, RunOnceWorker(int(override_since_key))
 
     poll_gap_seconds = int(config.get("phabricator", "poll_gap_seconds", fallback="60"))
-    return source, PhabricatorWorker(logger, poll_gap_seconds)
+    return source, PhabricatorWorker(logger, poll_gap_seconds, is_dev)
 
 
 def _parse_mail(config: ConfigParser, logger: Logger):
@@ -114,7 +114,7 @@ class Settings:
     def __init__(self, config: ConfigParser):
         is_dev = config.has_section("dev")
         logger = _parse_logger(is_dev)
-        source, worker = _parse_pipeline(config, logger)
+        source, worker = _parse_pipeline(config, logger, is_dev)
         self.source = source
         self.worker = worker
         self.bugzilla_host = _parse_host(config.get("bugzilla", "host"))

--- a/phabricatoremails/worker.py
+++ b/phabricatoremails/worker.py
@@ -29,12 +29,14 @@ class PhabricatorWorker:
 
     _logger: Logger
     _poll_gap_seconds: int
+    _is_dev: bool
     _is_shutdown_requested: bool
     _is_sleeping: bool
 
-    def __init__(self, logger: Logger, poll_gap_seconds: int):
+    def __init__(self, logger: Logger, poll_gap_seconds: int, is_dev: bool):
         self._logger = logger
         self._poll_gap_seconds = poll_gap_seconds
+        self._is_dev = is_dev
         self._is_shutdown_requested = False
         self._is_sleeping = False
 
@@ -81,10 +83,11 @@ class PhabricatorWorker:
                 )
 
                 if is_caught_up and not self._is_shutdown_requested:
-                    self._logger.debug(
-                        f"Caught up with feed, sleeping for "
-                        f"{self._poll_gap_seconds} seconds..."
-                    )
+                    if self._is_dev:
+                        self._logger.debug(
+                            f"Caught up with feed, sleeping for "
+                            f"{self._poll_gap_seconds} seconds..."
+                        )
 
                     self._is_sleeping = True
                     try:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -44,7 +44,7 @@ def test_parse_file_pipeline():
     file=example.json
     """
     )
-    source, worker = _parse_pipeline(config, Any)
+    source, worker = _parse_pipeline(config, Any, True)
     assert isinstance(source, FileSource)
     assert isinstance(worker, RunOnceWorker)
 
@@ -60,7 +60,7 @@ def test_parse_run_once_pipeline():
     since_key=10
     """
     )
-    source, worker = _parse_pipeline(config, Any)
+    source, worker = _parse_pipeline(config, Any, True)
     assert isinstance(source, PhabricatorSource)
     assert isinstance(worker, RunOnceWorker)
 
@@ -77,7 +77,7 @@ def test_parse_production_pipeline():
     story_limit=10
     """
     )
-    source, worker = _parse_pipeline(config, Any)
+    source, worker = _parse_pipeline(config, Any, True)
     assert isinstance(source, PhabricatorSource)
     assert isinstance(worker, PhabricatorWorker)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -16,7 +16,7 @@ def test_poll_caught_up():
     def pipeline(*unused):
         return 10
 
-    worker = PhabricatorWorker(create_dev_logger(), 60)
+    worker = PhabricatorWorker(create_dev_logger(), 60, False)
     caught_up = worker._poll(
         MockQueryPositionStore(position=position), MockThreadStore(), pipeline
     )
@@ -30,7 +30,7 @@ def test_poll_fresh_events():
     def pipeline(*unused):
         return 20
 
-    worker = PhabricatorWorker(create_dev_logger(), 60)
+    worker = PhabricatorWorker(create_dev_logger(), 60, False)
     caught_up = worker._poll(
         MockQueryPositionStore(position=position), MockThreadStore(), pipeline
     )


### PR DESCRIPTION
Though useful for determining whether or not the service found events
created while in local dev, the amount of logs that are created in
DEV/PROD/etc are excessive according to ops.
Avoid printing the offending logs outside local dev accordingly.