### PR TITLE
Bug 1672239: Catch errors encountered when sending mail

### DIFF
--- a/phabricatoremails/cli.py
+++ b/phabricatoremails/cli.py
@@ -33,12 +33,13 @@ def parse_command():
 
 def cli():
     args = parse_command()
-    settings = Settings.load(os.environ.get(SETTINGS_PATH_ENV_KEY))
+    stats = StatsClient()
+    settings = Settings.load(stats, os.environ.get(SETTINGS_PATH_ENV_KEY))
     if settings.sentry_dsn:
         sentry_sdk.init(settings.sentry_dsn)
 
     parameters = [settings]
     if args.func == service:
-        parameters.append(StatsClient())
+        parameters.append(stats)
 
     args.func(*parameters)

--- a/phabricatoremails/constants.py
+++ b/phabricatoremails/constants.py
@@ -3,6 +3,7 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Strings used to define statistics
-STAT_FAILED_TO_SEND_MAIL = "mail.outgoing.sent"
+STAT_PROCESSED_MAIL = "mail.processed.sent"
 STAT_FAILED_TO_RENDER_EVENT = "mail.eventrender.failed"
 STAT_FAILED_TO_REQUEST_FROM_PHABRICATOR = "mail.phabricator_request.failed"
+STAT_FAILED_TO_SEND_MAIL = "mail.outgoing.failed"

--- a/phabricatoremails/error_notify.py
+++ b/phabricatoremails/error_notify.py
@@ -15,6 +15,11 @@ class ErrorNotify:
     _stats: StatsClient
 
     def notify(self, exception: Exception, warning: str, failure_stat: str):
+        """Report the exception to local logging and remote error tracking.
+
+        Logs the exception, logs the custom message, sends the exception to Sentry and
+        increments the specified error statistic.
+        """
         formatted_exception = traceback.format_exception(
             type(exception), exception, exception.__traceback__
         )

--- a/phabricatoremails/error_notify.py
+++ b/phabricatoremails/error_notify.py
@@ -1,0 +1,24 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import traceback
+from dataclasses import dataclass
+from typing import Any
+
+import sentry_sdk
+from statsd import StatsClient
+
+
+@dataclass
+class ErrorNotify:
+    _logger: Any
+    _stats: StatsClient
+
+    def notify(self, exception: Exception, warning: str, failure_stat: str):
+        formatted_exception = traceback.format_exception(
+            type(exception), exception, exception.__traceback__
+        )
+        self._logger.warning(formatted_exception)
+        self._logger.warning(warning)
+        sentry_sdk.capture_exception(exception)
+        self._stats.incr(failure_stat)

--- a/phabricatoremails/error_notify.py
+++ b/phabricatoremails/error_notify.py
@@ -1,9 +1,7 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import traceback
 from dataclasses import dataclass
-from typing import Any
 
 import sentry_sdk
 from statsd import StatsClient
@@ -11,19 +9,12 @@ from statsd import StatsClient
 
 @dataclass
 class ErrorNotify:
-    _logger: Any
     _stats: StatsClient
 
-    def notify(self, exception: Exception, warning: str, failure_stat: str):
-        """Report the exception to local logging and remote error tracking.
+    def notify(self, exception: Exception, failure_stat: str):
+        """Report the exception to remote error tracking.
 
-        Logs the exception, logs the custom message, sends the exception to Sentry and
-        increments the specified error statistic.
+        Sends the exception to Sentry and increments the specified error statistic.
         """
-        formatted_exception = traceback.format_exception(
-            type(exception), exception, exception.__traceback__
-        )
-        self._logger.warning(formatted_exception)
-        self._logger.warning(warning)
         sentry_sdk.capture_exception(exception)
         self._stats.incr(failure_stat)

--- a/phabricatoremails/settings.py
+++ b/phabricatoremails/settings.py
@@ -127,7 +127,7 @@ class Settings:
         self.bugzilla_host = _parse_host(config.get("bugzilla", "host"))
         self.phabricator_host = _parse_host(config.get("phabricator", "host"))
         self.logger = logger
-        self.error_notify = ErrorNotify(self.logger, stats)
+        self.error_notify = ErrorNotify(stats)
         self.sentry_dsn = config.get("sentry", "dsn", fallback="")
         self.db_url = config.get("db", "url")
         self.is_dev = is_dev

--- a/tests/mock_error_notify.py
+++ b/tests/mock_error_notify.py
@@ -4,5 +4,5 @@
 
 
 class MockErrorNotify:
-    def notify(self, exception: Exception, warning: str, failure_stat: str):
+    def notify(self, exception: Exception, failure_stat: str):
         pass

--- a/tests/mock_error_notify.py
+++ b/tests/mock_error_notify.py
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+class MockErrorNotify:
+    def notify(self, exception: Exception, warning: str, failure_stat: str):
+        pass

--- a/tests/mock_settings.py
+++ b/tests/mock_settings.py
@@ -1,8 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-import logging
+from phabricatoremails import logging
 
 
 class MockSettings:
@@ -20,7 +19,7 @@ class MockSettings:
         db=None,
         mail=None,
     ):
-        self.logger = logging.getLogger()
+        self.logger = logging.create_dev_logger()
         self.source = source
         self.worker = worker
         self.bugzilla_host = bugzilla_host

--- a/tests/mock_settings.py
+++ b/tests/mock_settings.py
@@ -13,6 +13,7 @@ class MockSettings:
         worker=None,
         bugzilla_host=None,
         phabricator_host=None,
+        error_notify=None,
         sentry_dsn="",
         db_url="",
         is_dev=False,
@@ -24,6 +25,7 @@ class MockSettings:
         self.worker = worker
         self.bugzilla_host = bugzilla_host
         self.phabricator_host = phabricator_host
+        self.error_notify = error_notify
         self.sentry_dsn = sentry_dsn
         self.db_url = db_url
         self.is_dev = is_dev

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 from phabricatoremails import logging
 from phabricatoremails.mail import SmtpMail, OutgoingEmail, SesMail
-
+from tests.mock_error_notify import MockErrorNotify
 
 MOCK_EMAIL = OutgoingEmail(
     "template",
@@ -21,7 +21,9 @@ MOCK_EMAIL = OutgoingEmail(
 
 def test_smtp():
     smtp_server = Mock()
-    mail = SmtpMail(smtp_server, "from@mail", logging.create_dev_logger(), None)
+    mail = SmtpMail(
+        smtp_server, "from@mail", logging.create_dev_logger(), MockErrorNotify(), None
+    )
     mail.send([MOCK_EMAIL])
     smtp_server.sendmail.assert_called_with(
         "from@mail",
@@ -36,7 +38,9 @@ def test_smtp():
 
 def test_ses():
     client = Mock()
-    mail = SesMail(client, "from@mail", logging.create_dev_logger(), None)
+    mail = SesMail(
+        client, "from@mail", logging.create_dev_logger(), MockErrorNotify(), None
+    )
     mail.send([MOCK_EMAIL])
     ses_kwargs = client.send_raw_email.call_args.kwargs
     assert ses_kwargs["Destinations"] == ["to@mail"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,6 +18,8 @@ from phabricatoremails.settings import (
 )
 from phabricatoremails.source import FileSource, PhabricatorSource
 from phabricatoremails.worker import RunOnceWorker, PhabricatorWorker
+from tests.mock_error_notify import MockErrorNotify
+from tests.mock_settings import MockStats
 
 
 def _config_parser(ini_contents: str):
@@ -94,7 +96,7 @@ def test_parse_ses_mail(mock_boto3_client):
     [email-ses]
     """
     )
-    mail = _parse_mail(config, Any)
+    mail = _parse_mail(config, Any, MockErrorNotify())
     assert isinstance(mail, SesMail)
 
 
@@ -111,7 +113,7 @@ def test_parse_smtp_mail(mock_smtp):
     host=smtp-host
     """
     )
-    mail = _parse_mail(config, Any)
+    mail = _parse_mail(config, Any, MockErrorNotify())
     assert isinstance(mail, SmtpMail)
 
 
@@ -125,7 +127,7 @@ def test_parse_fs_mail(tmp_path):
     "output_path={tmp_path}
     """
     )
-    mail = _parse_mail(config, Any)
+    mail = _parse_mail(config, Any, MockErrorNotify())
     assert isinstance(mail, FsMail)
 
 
@@ -145,7 +147,7 @@ def test_settings():
     url=postgres://db
     """
     )
-    settings = Settings(config)
+    settings = Settings(config, MockStats())
     assert settings.phabricator_host == "phabricator.host"
     assert settings.bugzilla_host == "bugzilla.host"
 
@@ -158,4 +160,4 @@ def test_settings_missing_property_throws_error():
         """
     )
     with pytest.raises(configparser.Error):
-        Settings(config)
+        Settings(config, MockStats())


### PR DESCRIPTION
The only remaining uncaught failure case in the pipeline is when
mail is sent.

This patch catches that issue, but also refactors error handling a bit
so that common error-reporting logic is shared.