### PR TITLE
Bug 1672239: Improve resiliency towards render/send failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ url=[!] postgresql://dev:dev@127.0.0.1/phabricator_emails
 from_address=phabricator@mozilla.com
 ; chooses which email implementation to use. Possible options are "fs", "smtp" and "ses"
 implementation=fs
+; time before retrying to send an email if a temporary error is encountered
+temporary_error_retry_delay_seconds=[optional] [default=30]
 
 ; one of the following three [email-*] sections need to be uncommented so that "phabricator-emails" knows
 ; which email driver to use.

--- a/phabricatoremails/constants.py
+++ b/phabricatoremails/constants.py
@@ -3,6 +3,9 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Strings used to define statistics
-STAT_FAILED_TO_SEND_MAIL = "mail.outgoing.sent"
-STAT_FAILED_TO_RENDER_EVENT = "mail.eventrender.failed"
+STAT_FAILED_TO_SEND_MAIL_TEMPORARY = "mail.outgoing.temporarily-failed"
+STAT_FAILED_TO_SEND_MINIMAL_CONTEXT_MAIL = "mail.outgoing.failed.minimal-context"
+STAT_FAILED_TO_SEND_FULL_CONTEXT_MAIL = "mail.outgoing.failed.full-context"
+STAT_FAILED_TO_RENDER_MINIMAL_CONTEXT_EVENT = "mail.eventrender.failed.minimal-context"
+STAT_FAILED_TO_RENDER_FULL_CONTEXT_EVENT = "mail.eventrender.failed.full-context"
 STAT_FAILED_TO_REQUEST_FROM_PHABRICATOR = "mail.phabricator_request.failed"

--- a/phabricatoremails/exception.py
+++ b/phabricatoremails/exception.py
@@ -1,0 +1,5 @@
+import traceback
+
+
+def render_exception(e: Exception):
+    return "".join(traceback.format_exception(type(e), e, e.__traceback__))

--- a/phabricatoremails/mail.py
+++ b/phabricatoremails/mail.py
@@ -205,10 +205,10 @@ class SesMail:
             # https://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html#API_SendRawEmail_Errors  # noqa
             error_code = error.response["Error"]["Code"]
             if error_code in (
-                "AccountSendingPaused",
+                "AccountSendingPausedException",
                 "ConfigurationSetDoesNotExist",
-                "ConfigurationSetSendingPaused",
-                "MailFromDomainNotVerified",
+                "ConfigurationSetSendingPausedException",
+                "MailFromDomainNotVerifiedException",
             ):
                 return SendEmailResult(
                     SendEmailState.TEMPORARY_FAILURE, error_code, error

--- a/phabricatoremails/render/events/phabricator.py
+++ b/phabricatoremails/render/events/phabricator.py
@@ -45,6 +45,16 @@ class Revision:
 
 
 @dataclass
+class MinimalRevision:
+    id: int
+    link: str
+
+    @classmethod
+    def parse(cls, revision: dict):
+        return cls(revision["revisionId"], revision["link"])
+
+
+@dataclass
 class ReplyContext:
     other_author: str
     other_date_utc: datetime

--- a/phabricatoremails/render/template.py
+++ b/phabricatoremails/render/template.py
@@ -23,6 +23,7 @@ EMOJI = {
     "airplane": 0x2708,
     "airplane_arrival": 0x1F6EC,
     "bell": 0x1F514,
+    "building_construction": 0x1F3D7,
     "check_mark": 0x2714,
     "circle_arrows": 0x1F504,
     "deny_x": 0x2716,

--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -50,6 +50,12 @@
     </div>
 {% endmacro %}
 
+{% macro minimal_title(revision) %}
+    <div class="title">
+        <a class="revision" href="{{ revision.link }}">D{{ revision.id }}</a>
+    </div>
+{% endmacro %}
+
 {% macro reviewer_action(reviewer, revision) %}
     {% if reviewer is soft_needed_reviewer %}
         <a href="{{ revision.link }}" class="actionable">{{ emoji("microscope") | safe }} A review is needed</a>

--- a/phabricatoremails/render/templates/html/minimal.html.jinja2
+++ b/phabricatoremails/render/templates/html/minimal.html.jinja2
@@ -1,0 +1,25 @@
+{% import '_macros.html.jinja2' as macros %}
+{{ macros.head() }}
+<div class="event-content">
+
+    {% call macros.preview(true, unique_number) %}
+        {{ emoji("building_construction") | safe }} An action occurred.
+    {% endcall %}
+
+    {{ macros.minimal_title(revision) }}
+
+    <div class="summary">
+        <span class="emoji">{{ emoji("building_construction") | safe }}</span>
+        <span class="text"><span>An (unknown) action occurred</span></span>
+        <a href="{{ revision.link }}" class="actionable">View the revision</a>
+    </div>
+
+    <div class="minimal-email-error-summary">
+        Due to an internal issue (it's been automatically reported!), we weren't
+        able to fetch the details on the action that happened to this revision.
+        You should <a href="{{ revision.link }}">view the revision on Phabricator</a>
+        to ensure that you're not missing anything important.
+    </div>
+
+    {{ macros.footer(recipient_username, unique_number) }}
+</div>

--- a/phabricatoremails/render/templates/html/style.css
+++ b/phabricatoremails/render/templates/html/style.css
@@ -471,6 +471,14 @@ except with some adjustments to make them "fit better" with our custom style.
     border-right: 1px solid #b6d9cb;
 }
 
+.minimal-email-error-summary {
+    padding: 4px 0 4px 10px;
+    margin-top: 10px;
+    border-left: 3px solid #c85a5a;
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+}
+
 .prevent-fold {
     display: none;
 }

--- a/phabricatoremails/render/templates/text/minimal.text.jinja2
+++ b/phabricatoremails/render/templates/text/minimal.text.jinja2
@@ -1,0 +1,12 @@
+{% import '_macros.text.jinja2' as macros %}
+
+{{- revision.link }}
+
+An (unknown) action occurred.
+
+Due to an internal issue (it's been automatically reported!), we weren't
+able to fetch the details on the action that happened to this revision.
+You should view the revision on Phabricator to ensure that you're not
+missing anything important.
+
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/service.py
+++ b/phabricatoremails/service.py
@@ -1,11 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+import enum
+import time
 import traceback
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
+from enum import Enum
+from logging import Logger
+from typing import Any, List, Callable
 
+import jinja2
 import sentry_sdk
 from phabricatoremails import PACKAGE_DIRECTORY
 from phabricatoremails.constants import (
@@ -14,13 +18,209 @@ from phabricatoremails.constants import (
     STAT_FAILED_TO_REQUEST_FROM_PHABRICATOR,
 )
 from phabricatoremails.db import DBNotInitializedError
-from phabricatoremails.mail import FsMail
+from phabricatoremails.mail import FsMail, SendEmailState, OutgoingEmail
 from phabricatoremails.render.render import Render
 from phabricatoremails.render.template import TemplateStore
 from phabricatoremails.settings import Settings
 from phabricatoremails.source import PhabricatorException
 from phabricatoremails.thread_store import ThreadStore
 from statsd import StatsClient
+
+
+_RENDER_EXCEPTIONS = (LookupError, TypeError, ValueError, jinja2.TemplateError)
+
+
+class ProcessEventState(Enum):
+    SUCCESS = enum.auto()
+    FAILED_TO_SEND = enum.auto()
+    FAILED_TO_RENDER = enum.auto()
+
+
+@dataclass
+class ProcessEventResult:
+    state: ProcessEventState
+    successfully_sent_email_count: int
+    failed_to_send_recipients: List[str] = field(default_factory=list)
+
+
+def _report_render_failure(
+    stats: StatsClient, logger: Logger, e: Exception, message: str
+):
+    stats.incr(STAT_FAILED_TO_RENDER_EVENT)
+    logger.warning(traceback.format_exc())
+    logger.warning(message)
+    sentry_sdk.capture_exception(e)
+
+
+def _send_emails(
+    mail,
+    stats: StatsClient,
+    logger: Logger,
+    emails: List[OutgoingEmail],
+    on_permanent_failure_message: str,
+) -> List[str]:
+    """Attempt to send emails, retrying if necessary.
+
+    Returns list of recipient email addresses who had an email that failed to be sent
+    to them.
+    """
+
+    failed_recipients = []
+    for email in emails:
+        while True:
+            result = mail.send(email)
+            if result.status == SendEmailState.TEMPORARY_FAILURE:
+                stats.incr(STAT_FAILED_TO_SEND_MAIL)
+                logger.warning(
+                    'Encountered temporary failure while sending email: "{}"'.format(
+                        result.reason_text
+                    )
+                )
+
+                # "Temporary failures" can be anything from a transient network glitch
+                # to something as serious and long-lived as Amazon pausing our
+                # ability to send emails. 30 seconds seemed like a good balance between
+                # being responsive and filling the logs with "temporary failure"
+                # warnings.
+                logger.warning("Sleeping for 30 seconds")
+                time.sleep(30)
+                continue  # retry sending this email
+            elif result.status == SendEmailState.PERMANENT_FAILURE:
+                stats.incr(STAT_FAILED_TO_SEND_MAIL)
+                sentry_sdk.capture_exception(result.exception)
+                logger.error(
+                    'Encountered permanent failure while sending email: "{}"'.format(
+                        result.reason_text
+                    )
+                )
+                logger.error(on_permanent_failure_message)
+                failed_recipients.append(email.to)
+            break
+
+    return failed_recipients
+
+
+def process_emails_full(
+    timestamp: int,
+    event: dict,
+    render: Render,
+    thread_store: ThreadStore,
+    stats: StatsClient,
+    logger: Logger,
+    mail,
+) -> ProcessEventResult:
+    # We have full context if it's on the event ("context") or if Bug 1672239
+    # hasn't landed yet (no minimal context, event *is* the full context).
+    has_full_context = event.get("context", None) or "minimalContext" not in event
+    if not has_full_context:
+        return ProcessEventResult(ProcessEventState.FAILED_TO_RENDER, 0)
+
+    # Before Bug 1672239, "event" has all the properties that would be
+    # on "context".
+    full_context = event.get("context", event)
+    try:
+        is_secure = event["isSecure"]
+        emails = render.process_event_to_emails_with_full_context(
+            is_secure, timestamp, full_context, thread_store
+        )
+    except _RENDER_EXCEPTIONS as e:
+        _report_render_failure(
+            stats,
+            logger,
+            e,
+            "Failed to render emails for a Phabricator event with full "
+            "context. Falling back to sending a simpler, more resilient "
+            "email.",
+        )
+        return ProcessEventResult(ProcessEventState.FAILED_TO_RENDER, 0)
+
+    failed_recipients = _send_emails(
+        mail,
+        stats,
+        logger,
+        emails,
+        "Falling back to sending a minimal email to this recipient.",
+    )
+    if failed_recipients:
+        return ProcessEventResult(
+            ProcessEventState.FAILED_TO_SEND,
+            len(emails) - len(failed_recipients),
+            failed_recipients,
+        )
+
+    return ProcessEventResult(ProcessEventState.SUCCESS, len(emails))
+
+
+def process_events_minimal(
+    timestamp: int,
+    minimal_context: dict,
+    render: Render,
+    thread_store: ThreadStore,
+    stats: StatsClient,
+    logger: Logger,
+    mail,
+    recipient_filter: Callable[[str], bool],
+) -> int:
+    try:
+        emails = render.process_event_to_emails_with_minimal_context(
+            timestamp, minimal_context, thread_store
+        )
+    except _RENDER_EXCEPTIONS as e:
+        _report_render_failure(
+            stats,
+            logger,
+            e,
+            "Failed to render emails for a Phabricator event with minimal "
+            "context. Skipping event.",
+        )
+        return 0
+
+    emails = [email for email in emails if recipient_filter(email.to)]
+    failed_recipients = _send_emails(mail, stats, logger, emails, "Skipping email.")
+    return len(emails) - len(failed_recipients)
+
+
+def process_event(
+    event: dict,
+    render: Render,
+    thread_store: ThreadStore,
+    logger: Logger,
+    stats: StatsClient,
+    mail,
+) -> int:
+    timestamp = event["timestamp"]
+    result = process_emails_full(
+        timestamp, event, render, thread_store, stats, logger, mail
+    )
+    successful_full_email_count = result.successfully_sent_email_count
+    if result.state == ProcessEventState.SUCCESS:
+        return successful_full_email_count
+
+    def recipient_filter(recipient: str):
+        return (
+            result.state == ProcessEventState.FAILED_TO_RENDER
+            or recipient in result.failed_to_send_recipients
+        )
+
+    # If we've reached this point, we either don't have full context, or we've
+    # failed to render with full context.
+    minimal_context = event.get("minimalContext", None)
+    if not minimal_context:
+        # Bug 1672239 has not landed, so we can't fall back to rendering with
+        # minimal context. Skip this event.
+        return successful_full_email_count
+
+    successful_minimal_email_count = process_events_minimal(
+        timestamp,
+        minimal_context,
+        render,
+        thread_store,
+        stats,
+        logger,
+        mail,
+        recipient_filter,
+    )
+    return successful_minimal_email_count + successful_full_email_count
 
 
 @dataclass
@@ -56,21 +256,14 @@ class Pipeline:
                 )
             )
 
-        emails = []
+        email_count = 0
         for event in result["data"]["events"]:
-            try:
-                emails += self._render.process_event_to_emails(event, thread_store)
-            except Exception as e:
-                self._logger.warning(traceback.format_exc())
-                self._logger.warning(
-                    "Failed to send emails for a Phabricator event, "
-                    "skipping the event and continuing."
-                )
-                sentry_sdk.capture_exception(e)
-                self._stats.incr(STAT_FAILED_TO_RENDER_EVENT)
+            email_count += process_event(
+                event, self._render, thread_store, self._logger, self._stats, self._mail
+            )
 
-        self._mail.send(emails)
-        self._stats.incr(STAT_FAILED_TO_SEND_MAIL, count=len(emails))
+        if self._is_dev:
+            self._logger.debug(f"Sent {email_count} emails.")
         return int(result["cursor"]["after"])
 
 

--- a/phabricatoremails/settings.py
+++ b/phabricatoremails/settings.py
@@ -109,6 +109,7 @@ class Settings:
     sentry_dsn: str
     db_url: str
     is_dev: bool
+    temporary_mail_error_retry_seconds: int
     _config: ConfigParser
 
     def __init__(self, config: ConfigParser):
@@ -123,6 +124,9 @@ class Settings:
         self.sentry_dsn = config.get("sentry", "dsn", fallback="")
         self.db_url = config.get("db", "url")
         self.is_dev = is_dev
+        self.temporary_mail_error_retry_seconds = int(
+            config.get("mail", "temporary_retry_delay_seconds", fallback="30")
+        )
         self._config = config
 
     def db(self):

--- a/phabricatoremails/settings.py
+++ b/phabricatoremails/settings.py
@@ -125,7 +125,7 @@ class Settings:
         self.db_url = config.get("db", "url")
         self.is_dev = is_dev
         self.temporary_mail_error_retry_seconds = int(
-            config.get("mail", "temporary_retry_delay_seconds", fallback="30")
+            config.get("email", "temporary_error_retry_delay_seconds", fallback="30")
         )
         self._config = config
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@
 alembic==1.5.8
 black==20.8b1
 boto3==1.17.41
+botocore==1.20.41
 dockerflow==2020.10.0
 flake8==3.9.0
 jinja2==2.11.3

--- a/settings.production-example.ini
+++ b/settings.production-example.ini
@@ -23,6 +23,7 @@ url=[!] postgresql://dev:dev@127.0.0.1/phabricator_emails
 ; the "from" address of each email
 from_address=phabricator@mozilla.com
 implementation=ses
+temporary_error_retry_delay_seconds=[optional] [default=30]
 
 [email-ses]
 aws_access_key_id=[!] [optional] token

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ max-line-length = 88
 # https://github.com/python/mypy/issues/9940
 [mypy]
 
-[mypy-sqlalchemy.*,alembic.*,boto3.*,statsd.*,premailer.*]
+[mypy-sqlalchemy.*,alembic.*,boto3.*,botocore.*,statsd.*,premailer.*]
 ignore_missing_imports = True

--- a/tests/mock_mail.py
+++ b/tests/mock_mail.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from phabricatoremails.mail import OutgoingEmail
+from phabricatoremails.mail import SendEmailState, SendEmailResult
 
 
 class MockMail:
-    def send(self, emails: list[OutgoingEmail]):
-        pass
+    def send(self, _):
+        return SendEmailResult(SendEmailState.SUCCESS)

--- a/tests/mock_settings.py
+++ b/tests/mock_settings.py
@@ -16,6 +16,7 @@ class MockSettings:
         sentry_dsn="",
         db_url="",
         is_dev=False,
+        temporary_mail_error_retry_seconds=0,
         db=None,
         mail=None,
     ):
@@ -27,6 +28,7 @@ class MockSettings:
         self.sentry_dsn = sentry_dsn
         self.db_url = db_url
         self.is_dev = is_dev
+        self.temporary_mail_error_retry_seconds = temporary_mail_error_retry_seconds
         self._db = db
         self._mail = mail
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -6,8 +6,13 @@ from unittest import mock
 from unittest.mock import Mock
 
 from phabricatoremails import logging
-from phabricatoremails.mail import SmtpMail, OutgoingEmail, SesMail
-
+from phabricatoremails.mail import (
+    SmtpMail,
+    OutgoingEmail,
+    SesMail,
+    SendEmailResult,
+    SendEmailState,
+)
 
 MOCK_EMAIL = OutgoingEmail(
     "template",
@@ -22,7 +27,8 @@ MOCK_EMAIL = OutgoingEmail(
 def test_smtp():
     smtp_server = Mock()
     mail = SmtpMail(smtp_server, "from@mail", logging.create_dev_logger(), None)
-    mail.send([MOCK_EMAIL])
+    result = mail.send(MOCK_EMAIL)
+    assert result == SendEmailResult(SendEmailState.SUCCESS)
     smtp_server.sendmail.assert_called_with(
         "from@mail",
         "to@mail",
@@ -37,7 +43,8 @@ def test_smtp():
 def test_ses():
     client = Mock()
     mail = SesMail(client, "from@mail", logging.create_dev_logger(), None)
-    mail.send([MOCK_EMAIL])
+    result = mail.send(MOCK_EMAIL)
+    assert result == SendEmailResult(SendEmailState.SUCCESS)
     ses_kwargs = client.send_raw_email.call_args.kwargs
     assert ses_kwargs["Destinations"] == ["to@mail"]
     assert ses_kwargs["Source"] == "from@mail"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8,10 +8,15 @@ import pytest
 from kgb import spy_on
 from phabricatoremails import logging
 from phabricatoremails.db import DBNotInitializedError
-from phabricatoremails.mail import OutgoingEmail, FsMail
+from phabricatoremails.mail import (
+    OutgoingEmail,
+    FsMail,
+    SendEmailResult,
+    SendEmailState,
+)
 from phabricatoremails.render.render import Render
 from phabricatoremails.render.template import TemplateStore
-from phabricatoremails.service import Pipeline, service
+from phabricatoremails.service import Pipeline, service, process_event, _send_emails
 from tests.mock_db import MockDB
 from tests.mock_mail import MockMail
 from tests.mock_settings import MockStats, MockSettings
@@ -140,7 +145,7 @@ def test_integration_pipeline():
 
         emails = []
         for call in mail.send.calls:
-            emails.extend(call.args[0])
+            emails.append(call.args[0])
 
     _assert_mail(
         emails[0],
@@ -170,7 +175,9 @@ def test_pipeline_returns_same_position_if_fetch_fails():
     assert pipeline.run(MockThreadStore(), 10) == 10
 
 
-def test_pipeline_skips_events_that_fail_to_render():
+def test_pipeline_skips_events_that_fail_to_render_and_have_no_minimal_context():
+    # Note: this behaviour is only needed until Bug 1672239 lands server-side,
+    # at which point "minimalContext" is expected to exist.
     source = MockSource(
         next_result={
             "data": {
@@ -184,9 +191,17 @@ def test_pipeline_skips_events_that_fail_to_render():
                         "body": {
                             "reviewers": [
                                 {
-                                    "email": "2@mail",
-                                    "timezoneOffset": 0,
-                                    "isActor": False,
+                                    "name": "2",
+                                    "isActionable": False,
+                                    "status": "unreviewed",
+                                    "recipients": [
+                                        {
+                                            "username": "2",
+                                            "email": "2@mail",
+                                            "timezoneOffset": 0,
+                                            "isActor": False,
+                                        }
+                                    ],
                                 }
                             ],
                             "commentCount": 1,
@@ -198,7 +213,10 @@ def test_pipeline_skips_events_that_fail_to_render():
                             "bug": {"bugId": 1, "link": "link"},
                         },
                     },
-                    {"thisEventIsMissingProperties": True},
+                    {
+                        "timestamp": 123,
+                        "thisEventIsMissingProperties": True,
+                    },
                 ],
             },
             "cursor": {"after": 20},
@@ -223,6 +241,171 @@ def test_pipeline_updates_position_even_if_no_new_events():
     pipeline = Pipeline(source, None, MockMail(), logger, MockStats(), False)
     new_position = pipeline.run(MockThreadStore(), 10)
     assert new_position == 20
+
+
+def test_processes_with_minimal_context_if_no_full_context():
+    event = {
+        "isSecure": True,
+        "timestamp": 0,
+        "context": None,
+        "minimalContext": {
+            "revision": {
+                "revisionId": 1,
+                "link": "link",
+            },
+            "recipients": [
+                {
+                    "username": "2",
+                    "email": "2@mail",
+                    "timezoneOffset": 0,
+                    "isActor": False,
+                }
+            ],
+        },
+    }
+    mail = MockMail()
+    render = Render(TemplateStore("", "", False))
+    logger = logging.create_dev_logger()
+    with spy_on(mail.send):
+        process_event(event, render, MockThreadStore(), logger, MockStats(), mail)
+        assert len(mail.send.calls) == 1
+        assert mail.send.calls[0].args[0].template_path == "minimal"
+
+
+def test_processes_with_minimal_context_if_full_context_error():
+    event = {
+        "isSecure": True,
+        "timestamp": 0,
+        "context": {
+            "thisContextIsMissingProperties": True,
+        },
+        "minimalContext": {
+            "revision": {
+                "revisionId": 1,
+                "link": "link",
+            },
+            "recipients": [
+                {
+                    "username": "2",
+                    "email": "2@mail",
+                    "timezoneOffset": 0,
+                    "isActor": False,
+                }
+            ],
+        },
+    }
+    mail = MockMail()
+    render = Render(TemplateStore("", "", False))
+    logger = logging.create_dev_logger()
+    with spy_on(mail.send):
+        process_event(event, render, MockThreadStore(), logger, MockStats(), mail)
+        assert len(mail.send.calls) == 1
+        assert mail.send.calls[0].args[0].template_path == "minimal"
+
+
+@patch("phabricatoremails.service._send_emails")
+def test_retries_failed_full_sends_with_minimal_emails(send_emails_fn):
+    event = {
+        "timestamp": 0,
+        "isSecure": True,
+        "context": {
+            "eventKind": "revision-reclaimed",
+            "actorName": "1",
+            "body": {
+                "reviewers": [
+                    {
+                        "name": "2",
+                        "isActionable": False,
+                        "status": "unreviewed",
+                        "recipients": [
+                            {
+                                "username": "2",
+                                "email": "2@mail",
+                                "timezoneOffset": 0,
+                                "isActor": False,
+                            },
+                            {
+                                "username": "3",
+                                "email": "3@mail",
+                                "timezoneOffset": 0,
+                                "isActor": False,
+                            },
+                        ],
+                    }
+                ],
+                "commentCount": 1,
+                "transactionLink": "link",
+            },
+            "revision": {
+                "revisionId": 1,
+                "link": "link",
+                "bug": {"bugId": 1, "link": "link"},
+            },
+        },
+        "minimalContext": {
+            "revision": {
+                "revisionId": 1,
+                "link": "link",
+            },
+            "recipients": [
+                {
+                    "username": "2",
+                    "email": "2@mail",
+                    "timezoneOffset": 0,
+                    "isActor": False,
+                },
+                {
+                    "username": "3",
+                    "email": "3@mail",
+                    "timezoneOffset": 0,
+                    "isActor": False,
+                },
+            ],
+        },
+    }
+
+    send_emails_fn.side_effect = [["2@mail"], []]
+    render = Render(TemplateStore("", "", False))
+    logger = logging.create_dev_logger()
+    process_event(event, render, MockThreadStore(), logger, MockStats(), None)
+    assert len(send_emails_fn.call_args_list) == 2
+    assert len(send_emails_fn.call_args_list[1][0][3]) == 1
+    _assert_mail(
+        send_emails_fn.call_args_list[1][0][3][0],
+        "D1",
+        "2@mail",
+        "An (unknown) action occurred",
+    )
+
+
+@patch("time.sleep")
+def test_retries_temporary_email_failures(_):
+    class FailOnceMail:
+        def __init__(self):
+            self.call_count = 0
+
+        def send(self, _):
+            self.call_count += 1
+            if self.call_count == 1:
+                return SendEmailResult(SendEmailState.TEMPORARY_FAILURE, "oops")
+            return SendEmailResult(SendEmailState.SUCCESS)
+
+    mail = FailOnceMail()
+    _send_emails(
+        mail,
+        MockStats(),
+        logging.create_dev_logger(),
+        [OutgoingEmail("", "", "", 0, "", "")],
+        "",
+    )
+    _send_emails(
+        mail,
+        MockStats(),
+        logging.create_dev_logger(),
+        [OutgoingEmail("", "", "", 1, "", "")],
+        "",
+    )
+    assert mail.call_count == 3
 
 
 def test_service_runs_worker():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,6 +9,8 @@ from typing import Any
 from unittest import mock
 
 import pytest
+
+from phabricatoremails import logging
 from phabricatoremails.mail import SesMail, SmtpMail, FsMail
 from phabricatoremails.settings import (
     _parse_logger,
@@ -125,7 +127,7 @@ def test_parse_fs_mail(tmp_path):
     "output_path={tmp_path}
     """
     )
-    mail = _parse_mail(config, Any)
+    mail = _parse_mail(config, logging.create_dev_logger())
     assert isinstance(mail, FsMail)
 
 


### PR DESCRIPTION
Drastically reduces the number of cases where we'd "lose" an email
by falling back to a "minimal" variant, if possible.

Note that a tradeoff was made here such that it's still possible
to lose an email if it can't be rendered or sent, even in
minimal form:

IMHO, an ideal solution would have been to block the queue if a
minimal email cannot be rendered or sent. However, due to
trickiness in tracking state to avoid double-sends (what if the
full context fails to be sent to half the recipients, but we fail
to render the minimal context for those unfortunate few?), it
seemed more effective in the short-term to still skip emails
in these scenarios, but to loudly proclaim the issue in both
stats and Sentry.

As discussed in the bug, there's future work around managing state
so that emails don't become inaccurate if they're sent late. In
the same way, there's possible future work to completely avoid
dropped emails.