### PR TITLE
Bug 1703842: Use structural subtyping, apply type checking to tests

### DIFF
--- a/phabricatoremails/alembic/env.py
+++ b/phabricatoremails/alembic/env.py
@@ -5,11 +5,11 @@ import os
 
 from alembic import context
 from phabricatoremails import models
-from phabricatoremails.settings import Settings, SETTINGS_PATH_ENV_KEY
+from phabricatoremails.settings import IniSettings, SETTINGS_PATH_ENV_KEY
 from sqlalchemy import create_engine
 
 target_metadata = models.Base.metadata
-settings = Settings.load(os.environ.get(SETTINGS_PATH_ENV_KEY))
+settings = IniSettings.load(os.environ.get(SETTINGS_PATH_ENV_KEY))
 db_url = settings.db_url
 
 

--- a/phabricatoremails/cli.py
+++ b/phabricatoremails/cli.py
@@ -9,7 +9,7 @@ import sentry_sdk
 from phabricatoremails.prepare import prepare
 from phabricatoremails.migrate import migrate
 from phabricatoremails.service import service
-from phabricatoremails.settings import Settings, SETTINGS_PATH_ENV_KEY
+from phabricatoremails.settings import IniSettings, SETTINGS_PATH_ENV_KEY
 from statsd import StatsClient
 
 
@@ -33,7 +33,7 @@ def parse_command():
 
 def cli():
     args = parse_command()
-    settings = Settings.load(os.environ.get(SETTINGS_PATH_ENV_KEY))
+    settings = IniSettings.load(os.environ.get(SETTINGS_PATH_ENV_KEY))
     if settings.sentry_dsn:
         sentry_sdk.init(settings.sentry_dsn)
 

--- a/phabricatoremails/mail.py
+++ b/phabricatoremails/mail.py
@@ -11,9 +11,10 @@ from email.mime.text import MIMEText
 from email.utils import formatdate
 from enum import Enum
 from logging import Logger
-from typing import Optional, Any
+from typing import Optional, Protocol
 
 import boto3
+from mypy_boto3_ses import SESClient
 
 
 class SendEmailState(Enum):
@@ -54,6 +55,11 @@ class OutgoingEmail:
         msg.attach(MIMEText(self.text_contents, "plain"))
         msg.attach(MIMEText(self.html_contents, "html"))
         return msg
+
+
+class Mail(Protocol):
+    def send(self, email: OutgoingEmail) -> SendEmailResult:
+        pass
 
 
 class FsMail:
@@ -140,7 +146,7 @@ class SmtpMail:
 class SesMail:
     """Sends emails via Amazon SES."""
 
-    _client: Any
+    _client: SESClient
     _from_address: str
     _logger: Logger
     _send_to: Optional[str]

--- a/phabricatoremails/models.py
+++ b/phabricatoremails/models.py
@@ -1,12 +1,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from typing import Any
-
 from sqlalchemy import Boolean, Column, Integer, BigInteger, CheckConstraint
 from sqlalchemy.ext.declarative import declarative_base
 
-Base = declarative_base()  # type: Any
+Base = declarative_base()
 
 
 class QueryPosition(Base):

--- a/phabricatoremails/prepare.py
+++ b/phabricatoremails/prepare.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from phabricatoremails.db import DBInitializedError
-from phabricatoremails.query_position_store import QueryPositionStore
+from phabricatoremails.query_position_store import DBQueryPositionStore
 from phabricatoremails.settings import Settings
 
 
@@ -32,7 +32,7 @@ def prepare(settings: Settings):
     db.upgrade_schema()
 
     with db.session() as db_session:
-        worker.set_initial_position(QueryPositionStore(db_session), end_key)
+        worker.set_initial_position(DBQueryPositionStore(db_session), end_key)
 
     settings.logger.info(
         f'Database initialized, current Phabricator position is "{end_key}".'

--- a/phabricatoremails/query_position_store.py
+++ b/phabricatoremails/query_position_store.py
@@ -3,21 +3,23 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from phabricatoremails.models import QueryPosition
 from sqlalchemy.orm import Session
 
 
-@dataclass
-class QueryPositionStore:
-    """Perform operations on the QueryPosition table."""
+class QueryPositionStore(Protocol):
+    def get_position(self) -> QueryPosition:
+        """Get the current position on the Phabricator feed.
 
-    _db_session: Session
+        This position describes which Phabricator events
+        have already been processed, and which ones still
+        need their emails submitted.
+        """
+        pass
 
-    def get_position(self):
-        return self._db_session.query(QueryPosition).one()
-
-    def set_initial_position(self, position: int):
+    def set_initial_position(self, position_key: int):
         """Set starting position on Phabricator feed.
 
         Phabricator-emails needs to track its position on the feed so that it sends
@@ -26,5 +28,18 @@ class QueryPositionStore:
         This method should be called once (per installation of phabricator-emails) to
         seed the initial position to start from on the feed.
         """
-        position = QueryPosition(up_to_key=position)
+        pass
+
+
+@dataclass
+class DBQueryPositionStore:
+    """Perform operations on the QueryPosition table."""
+
+    _db_session: Session
+
+    def get_position(self):
+        return self._db_session.query(QueryPosition).one()
+
+    def set_initial_position(self, position_key: int):
+        position = QueryPosition(up_to_key=position_key)
         self._db_session.add(position)

--- a/phabricatoremails/render/mailbatch.py
+++ b/phabricatoremails/render/mailbatch.py
@@ -11,7 +11,6 @@ from phabricatoremails.render.events.phabricator import Revision
 from phabricatoremails.render.events.phabricator_secure import SecureRevision
 from phabricatoremails.render.template import TemplateStore
 
-
 PUBLIC_TEMPLATE_PATH_PREFIX = "public/"
 SECURE_TEMPLATE_PATH_PREFIX = "secure/"
 
@@ -94,7 +93,7 @@ class MailBatch:
         unique_number: int,
         timestamp: int,
         event,
-    ):
+    ) -> list[OutgoingEmail]:
         """Process all targets with the provided public event parameters."""
         return [
             self._process(
@@ -123,7 +122,7 @@ class MailBatch:
         unique_number: int,
         timestamp: int,
         event,
-    ):
+    ) -> list[OutgoingEmail]:
         """Process all targets with the provided secure event parameters."""
         return [
             self._process(

--- a/phabricatoremails/render/template.py
+++ b/phabricatoremails/render/template.py
@@ -5,7 +5,7 @@
 import textwrap
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Protocol
 
 import jinja2
 from phabricatoremails.render.events.common import Reviewer, ReviewerStatus
@@ -193,7 +193,7 @@ class Template:
     with complex email clients.
     """
 
-    _css_inline: Any
+    _css_inline: Premailer
     _html_template: jinja2.Template
     _text_template: jinja2.Template
 
@@ -204,7 +204,12 @@ class Template:
         return self._css_inline.transform(html, False), text
 
 
-class TemplateStore:
+class TemplateStore(Protocol):
+    def get(self, template_path: str) -> Template:
+        pass
+
+
+class JinjaTemplateStore:
     """Configures Jinja and exposes the templates.
 
     There's two sets of templates: text and html. Each set has its own

--- a/phabricatoremails/service.py
+++ b/phabricatoremails/service.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from logging import Logger
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import jinja2
 import sentry_sdk
@@ -21,11 +21,11 @@ from phabricatoremails.constants import (
 )
 from phabricatoremails.db import DBNotInitializedError
 from phabricatoremails.exception import render_exception
-from phabricatoremails.mail import FsMail, SendEmailState, OutgoingEmail
+from phabricatoremails.mail import FsMail, SendEmailState, OutgoingEmail, Mail
 from phabricatoremails.render.render import Render
-from phabricatoremails.render.template import TemplateStore
+from phabricatoremails.render.template import JinjaTemplateStore
 from phabricatoremails.settings import Settings
-from phabricatoremails.source import PhabricatorException
+from phabricatoremails.source import PhabricatorException, Source
 from phabricatoremails.thread_store import ThreadStore
 from statsd import StatsClient
 
@@ -282,10 +282,10 @@ def process_event(
 class Pipeline:
     """Fetch events from Phabricator and emails accordingly."""
 
-    _source: Any
-    _render: Any
-    _mail: Any
-    _logger: Any
+    _source: Source
+    _render: Render
+    _mail: Mail
+    _logger: Logger
     _retry_delay_seconds: int
     _stats: StatsClient
     _is_dev: bool
@@ -353,7 +353,7 @@ def service(settings: Settings, stats: StatsClient):
 
     raw_css_path = PACKAGE_DIRECTORY / "render/templates/html/style.css"
     css_text = raw_css_path.read_text()
-    template_store = TemplateStore(
+    template_store = JinjaTemplateStore(
         settings.phabricator_host,
         css_text,
         # Keep CSS classes when outputting to local files, since that indicates local

--- a/phabricatoremails/source.py
+++ b/phabricatoremails/source.py
@@ -5,9 +5,18 @@
 import json
 import pathlib
 from dataclasses import dataclass
+from typing import Protocol, Dict
 
 import requests
 from requests import RequestException
+
+
+class Source(Protocol):
+    def fetch_feed_end(self) -> int:
+        pass
+
+    def fetch_next(self, after: int) -> Dict:
+        pass
 
 
 class PhabricatorException(Exception):

--- a/phabricatoremails/thread_store.py
+++ b/phabricatoremails/thread_store.py
@@ -3,13 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from phabricatoremails.models import Thread
 from sqlalchemy.orm import Session
 
 
+class ThreadStore(Protocol):
+    def get_or_create(self, revision_id: int) -> Thread:
+        pass
+
+
 @dataclass
-class ThreadStore:
+class DBThreadStore:
     """Perform operations on the Thread table."""
 
     _db_session: Session

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@
 alembic==1.5.8
 black==20.8b1
 boto3==1.17.41
+boto3-stubs[ses]==1.17.41
 botocore==1.20.41
 dockerflow==2020.10.0
 flake8==3.9.0
@@ -17,4 +18,5 @@ pytest==6.2.2
 requests==2.25.1
 sentry-sdk==1.0.0
 sqlalchemy==1.4.4
+sqlalchemy-stubs==0.4
 statsd==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,10 @@ attrs==20.3.0 \
 black==20.8b1 \
     --hash=sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea
     # via -r requirements.in
+boto3-stubs[ses]==1.17.41 \
+    --hash=sha256:09c69096392c1f432b2b6cc8ff23dde3c3cc79fd0aeb0980db4ccaf2ebd9152b \
+    --hash=sha256:354c9de66948b893550dd87697628c5a40d809bbd78b10aea7671a6afd3f4706
+    # via -r requirements.in
 boto3==1.17.41 \
     --hash=sha256:8544878fa8c9cad6972d9c9aae1db1d8fa7a3bb0adabe2fa39e4842d182bb4d7 \
     --hash=sha256:d85b0e05d7de96169b0024b76b292be62b01ef6f5ca853a512506346b82d2abb
@@ -27,6 +31,7 @@ botocore==1.20.41 \
     --hash=sha256:5e88d19a1406ff92d52518ac70a1531582d7af537dc18c8ebc7ab54282c2fa23 \
     --hash=sha256:63f650fc96bce141e8194a761e6890fea2fba6e01253aefa31ae69f145015c21
     # via
+    #   -r requirements.in
     #   boto3
     #   s3transfer
 cachetools==4.2.1 \
@@ -232,6 +237,10 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
     # via flake8
+mypy-boto3-ses==1.17.41.0 \
+    --hash=sha256:0daab92c7f576ebf263e862b0dd883bcd3b365e55ab43517d6266030d088e8c5 \
+    --hash=sha256:c68235c5329bd62ecc358ddedd12ab4c92bcf0ddb3f543f1afe87e62bc5765ae
+    # via boto3-stubs
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
@@ -261,7 +270,9 @@ mypy==0.812 \
     --hash=sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506 \
     --hash=sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c \
     --hash=sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sqlalchemy-stubs
 packaging==20.9 \
     --hash=sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5 \
     --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
@@ -387,6 +398,10 @@ six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
     # via python-dateutil
+sqlalchemy-stubs==0.4 \
+    --hash=sha256:5eec7aa110adf9b957b631799a72fef396b23ff99fe296df726645d01e312aa5 \
+    --hash=sha256:c665d6dd4482ef642f01027fa06c3d5e91befabb219dc71fc2a09e7d7695f7ae
+    # via -r requirements.in
 sqlalchemy==1.4.4 \
     --hash=sha256:015c78ece6f62963dc2fb3b409cafb1e6d97040478fe0ac811ba22833489c19f \
     --hash=sha256:33da0ad3a913de9abac5a3fbac8e11993ce8c83431d123c216463239767db259 \
@@ -476,6 +491,7 @@ typing-extensions==3.7.4.3 \
     # via
     #   black
     #   mypy
+    #   sqlalchemy-stubs
 urllib3==1.26.4 \
     --hash=sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df \
     --hash=sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,18 @@ max-line-length = 88
 # [mypy] section is now required in setup.cfg due to this issue:
 # https://github.com/python/mypy/issues/9940
 [mypy]
+plugins = sqlmypy
+allow_redefinition = True
+warn_unused_configs = True
+disallow_subclassing_any = True
+check_untyped_defs = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+strict_equality = True
 
-[mypy-sqlalchemy.*,alembic.*,boto3.*,botocore.*,statsd.*,premailer.*]
+
+[mypy-sqlalchemy.*,alembic.*,boto3.*,botocore.*,kgb.*,statsd.*,premailer.*]
 ignore_missing_imports = True

--- a/tests/mock_settings.py
+++ b/tests/mock_settings.py
@@ -37,8 +37,3 @@ class MockSettings:
 
     def mail(self):
         return self._mail
-
-
-class MockStats:
-    def incr(self, *args, **kwargs):
-        pass

--- a/tests/mock_worker.py
+++ b/tests/mock_worker.py
@@ -1,11 +1,14 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from phabricatoremails.query_position_store import QueryPositionStore
 
 
 class MockWorker:
-    def set_initial_position(self, query_position_store, position: int):
+    def set_initial_position(
+        self, query_position_store: QueryPositionStore, position: int
+    ) -> int:
         pass
 
-    def process(self, db, pipeline_callback):
+    def process(self, db, pipeline_callback) -> None:
         pass

--- a/tests/render/mock_template.py
+++ b/tests/render/mock_template.py
@@ -7,12 +7,20 @@ from attr import dataclass
 
 
 class MockTemplateStore:
-    last_template_path: Optional[str]
-    last_template_params: Optional[dict]
+    _last_template_path: Optional[str]
+    _last_template_params: Optional[dict]
 
-    def get(self, template_path):
-        self.last_template_path = template_path
+    def get(self, template_path: str):
+        self._last_template_path = template_path
         return MockTemplate(self)
+
+    def last_template_path(self):
+        assert self._last_template_path
+        return self._last_template_path
+
+    def last_template_params(self):
+        assert self._last_template_params
+        return self._last_template_params
 
 
 @dataclass
@@ -20,5 +28,5 @@ class MockTemplate:
     store: MockTemplateStore
 
     def render(self, params):
-        self.store.last_template_params = params
+        self.store._last_template_params = params
         return "html", "text"

--- a/tests/render/test_mailbatch.py
+++ b/tests/render/test_mailbatch.py
@@ -108,7 +108,7 @@ def test_process_public_event():
     assert len(emails) == 1
     email = emails[0]
     assert email.subject == "D1: revision"
-    assert store.last_template_path == PUBLIC_TEMPLATE_PATH_PREFIX + "template-author"
+    assert store.last_template_path() == PUBLIC_TEMPLATE_PATH_PREFIX + "template-author"
 
 
 def test_process_secure_event():
@@ -121,7 +121,7 @@ def test_process_secure_event():
     assert len(emails) == 1
     email = emails[0]
     assert email.subject == "D2: (secure bug 1)"
-    assert store.last_template_path == SECURE_TEMPLATE_PATH_PREFIX + "template-author"
+    assert store.last_template_path() == SECURE_TEMPLATE_PATH_PREFIX + "template-author"
 
 
 def test_passes_arguments_to_template():
@@ -129,4 +129,4 @@ def test_passes_arguments_to_template():
     batch = MailBatch(store)
     batch.target(NON_ACTOR_RECIPIENT, "template-author", extra_template_param="value")
     batch.process(PUBLIC_REVISION, "actor", 0, 0, EVENT)
-    assert store.last_template_params["extra_template_param"] == "value"
+    assert store.last_template_params()["extra_template_param"] == "value"

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -113,14 +113,14 @@ def test_unique_number_is_different_for_each_thread_email():
     render.process_event_to_emails_with_full_context(
         False, 123, _create_public_context(1), thread_store
     )
-    assert template_store.last_template_params["unique_number"] == 1
+    assert template_store.last_template_params()["unique_number"] == 1
 
     render.process_event_to_emails_with_full_context(
         False, 123, _create_public_context(1), thread_store
     )
-    assert template_store.last_template_params["unique_number"] == 2
+    assert template_store.last_template_params()["unique_number"] == 2
 
     render.process_event_to_emails_with_full_context(
         False, 123, _create_public_context(2), thread_store
     )
-    assert template_store.last_template_params["unique_number"] == 1
+    assert template_store.last_template_params()["unique_number"] == 1

--- a/tests/render/test_template.py
+++ b/tests/render/test_template.py
@@ -22,7 +22,7 @@ from phabricatoremails.render.events.phabricator import (
 )
 from phabricatoremails.render.mailbatch import PUBLIC_TEMPLATE_PATH_PREFIX
 from phabricatoremails.render.template import (
-    TemplateStore,
+    JinjaTemplateStore,
     Template,
     _jinja_html,
     _jinja_text,
@@ -48,7 +48,7 @@ def test_templates_end_with_newline():
 
 
 def test_integration_templates():
-    template_store = TemplateStore("", "", False)
+    template_store = JinjaTemplateStore("", "", False)
     template = template_store.get(PUBLIC_TEMPLATE_PATH_PREFIX + "pinged")
 
     html, text = template.render(
@@ -73,7 +73,7 @@ def test_integration_templates():
 
 
 def test_template_throws_error_if_invalid_template():
-    template_store = TemplateStore("", "", False)
+    template_store = JinjaTemplateStore("", "", False)
     with pytest.raises(TemplateNotFound):
         template_store.get(PUBLIC_TEMPLATE_PATH_PREFIX + "invalid")
 
@@ -94,7 +94,7 @@ def test_template_is_rendered_with_parameters():
 
 
 def test_css_is_inlined():
-    template_store = TemplateStore(
+    template_store = JinjaTemplateStore(
         "",
         ".custom-class { display: none }",
         False,
@@ -127,7 +127,7 @@ def test_html_environment():
     date = datetime.fromtimestamp(10000, timezone.utc)
     html = template.render(
         {
-            "comment_context": ReplyContext("author", date, "comment"),
+            "comment_context": ReplyContext("author", date, CommentMessage("", "")),
             "timezone": timezone(timedelta(hours=-7)),
         }
     )
@@ -146,7 +146,7 @@ def test_text_environment():
     template = jinja_env.get_template("example.text.jinja2")
     text = template.render(
         {
-            "reviewer": Reviewer("reviewer", False, ReviewerStatus.ACCEPTED, None),
+            "reviewer": Reviewer("reviewer", False, ReviewerStatus.ACCEPTED, []),
             "raw_comment": "this is a long comment with a lot of text. This is to test "
             "that wrapping happens correctly when rendered down to text. ",
         }

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -4,7 +4,9 @@
 
 import pytest
 from kgb import spy_on
-from phabricatoremails.migrate import DBNotInitializedError, migrate
+
+from phabricatoremails.db import DBNotInitializedError
+from phabricatoremails.migrate import migrate
 from tests.mock_db import MockDB
 from tests.mock_settings import MockSettings
 
@@ -12,15 +14,15 @@ from tests.mock_settings import MockSettings
 def test_migrate_doesnt_upgrade_schema_if_not_initialized():
     db = MockDB(is_initialized=False)
     settings = MockSettings(db=db)
-    with spy_on(db.upgrade_schema):
+    with spy_on(db.upgrade_schema) as spy:
         with pytest.raises(DBNotInitializedError):
             migrate(settings)
-        assert not db.upgrade_schema.called
+        assert not spy.called
 
 
 def test_migrate_upgrades_schema():
     db = MockDB(is_initialized=True)
     settings = MockSettings(db=db)
-    with spy_on(db.upgrade_schema):
+    with spy_on(db.upgrade_schema) as spy:
         migrate(settings)
-        assert db.upgrade_schema.called
+        assert spy.called

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -11,5 +11,5 @@ def test_mypy():
     # We call mypy with a relative path because it seems to miss more typing issues
     # when called with an absolute path.
     subprocess.check_call(
-        ["mypy", "phabricatoremails/cli.py"], cwd=PACKAGE_DIRECTORY.parent
+        ["mypy", "phabricatoremails", "tests"], cwd=PACKAGE_DIRECTORY.parent
     )

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -4,7 +4,9 @@
 
 import pytest
 from kgb import spy_on
-from phabricatoremails.prepare import prepare, DBInitializedError
+
+from phabricatoremails.db import DBInitializedError
+from phabricatoremails.prepare import prepare
 from tests.mock_db import MockDB
 from tests.mock_settings import MockSettings
 from tests.mock_source import MockSource
@@ -14,10 +16,10 @@ from tests.mock_worker import MockWorker
 def test_prepare_doesnt_upgrade_schema_if_already_initialized():
     db = MockDB(is_initialized=True)
     settings = MockSettings(db=db)
-    with spy_on(db.upgrade_schema):
+    with spy_on(db.upgrade_schema) as spy:
         with pytest.raises(DBInitializedError):
             prepare(settings)
-        assert not db.upgrade_schema.called
+        assert not spy.called
 
 
 def test_prepare_upgrades_schema_and_sets_position():
@@ -25,7 +27,9 @@ def test_prepare_upgrades_schema_and_sets_position():
     worker = MockWorker()
     db = MockDB(is_initialized=False)
     settings = MockSettings(source=source, worker=worker, db=db)
-    with spy_on(db.upgrade_schema), spy_on(worker.set_initial_position):
+    with spy_on(db.upgrade_schema) as upgrade_spy, spy_on(
+        worker.set_initial_position
+    ) as position_spy:
         prepare(settings)
-        assert db.upgrade_schema.called
-        assert worker.set_initial_position.calls[0].args[1] == 50
+        assert upgrade_spy.called
+        assert position_spy.calls[0].args[1] == 50

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,8 +5,8 @@
 import configparser
 from configparser import ConfigParser
 from io import StringIO
-from typing import Any
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -16,7 +16,7 @@ from phabricatoremails.settings import (
     _parse_logger,
     _parse_pipeline,
     _parse_mail,
-    Settings,
+    IniSettings,
 )
 from phabricatoremails.source import FileSource, PhabricatorSource
 from phabricatoremails.worker import RunOnceWorker, PhabricatorWorker
@@ -46,7 +46,7 @@ def test_parse_file_pipeline():
     file=example.json
     """
     )
-    source, worker = _parse_pipeline(config, Any, True)
+    source, worker = _parse_pipeline(config, Mock(), True)
     assert isinstance(source, FileSource)
     assert isinstance(worker, RunOnceWorker)
 
@@ -62,7 +62,7 @@ def test_parse_run_once_pipeline():
     since_key=10
     """
     )
-    source, worker = _parse_pipeline(config, Any, True)
+    source, worker = _parse_pipeline(config, Mock(), True)
     assert isinstance(source, PhabricatorSource)
     assert isinstance(worker, RunOnceWorker)
 
@@ -79,7 +79,7 @@ def test_parse_production_pipeline():
     story_limit=10
     """
     )
-    source, worker = _parse_pipeline(config, Any, True)
+    source, worker = _parse_pipeline(config, Mock(), True)
     assert isinstance(source, PhabricatorSource)
     assert isinstance(worker, PhabricatorWorker)
 
@@ -96,7 +96,7 @@ def test_parse_ses_mail(mock_boto3_client):
     [email-ses]
     """
     )
-    mail = _parse_mail(config, Any)
+    mail = _parse_mail(config, Mock())
     assert isinstance(mail, SesMail)
 
 
@@ -113,7 +113,7 @@ def test_parse_smtp_mail(mock_smtp):
     host=smtp-host
     """
     )
-    mail = _parse_mail(config, Any)
+    mail = _parse_mail(config, Mock())
     assert isinstance(mail, SmtpMail)
 
 
@@ -147,7 +147,7 @@ def test_settings():
     url=postgres://db
     """
     )
-    settings = Settings(config)
+    settings = IniSettings(config)
     assert settings.phabricator_host == "phabricator.host"
     assert settings.bugzilla_host == "bugzilla.host"
 
@@ -160,4 +160,4 @@ def test_settings_missing_property_throws_error():
         """
     )
     with pytest.raises(configparser.Error):
-        Settings(config)
+        IniSettings(config)


### PR DESCRIPTION
Uses Protocols for applying type checking to polymorphism.
Applies mypy to tests, as opposed to just production code (this found
some test-specific bugs!)
Tightens the checks performed by mypy, increasing strictness.

I opted to leave "check_untyped_defs" off because applying full
annotations (including return types) seems excessive at the moment.