### PR TITLE
Bug 1633922: Use ellipsis on long file paths for comments

### DIFF
--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -85,7 +85,7 @@
 {% macro inline_comment(comment, recipient_timezone) %}
     <div class="inline-comment">
         <a href="{{ comment.link }}">
-            {{ comment.file_context }}
+            <span class="file-context"><span>{{ comment.file_context }}</span></span>
             <span class="view-inline">View inline</span>
         </a>
         {% if comment.context is reply %}

--- a/phabricatoremails/render/templates/html/style.css
+++ b/phabricatoremails/render/templates/html/style.css
@@ -289,16 +289,33 @@ blockquote {
 }
 
 .inline-comment > a[href] {
-    display: block;
+    display: flex;
     border-bottom: 1px solid #d8d8d8;
     color: #464c5c;
     padding: 4px 8px;
     text-decoration: none;
 }
 
+.inline-comment .file-context {
+    flex-grow: 1;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+
+    /* Place ellipsis on the front of the path */
+    direction: rtl;
+    text-align: left;
+}
+
+.inline-comment .file-context > span {
+    /* Resolve "direction: rtl" changing the position of slashes */
+    unicode-bidi: plaintext;
+}
+
 .inline-comment .view-inline {
-    float: right;
+    margin-left: 20px;
     text-decoration: underline;
+    white-space: nowrap;
 }
 
 .inline-comment .scroll-container {


### PR DESCRIPTION
Now that we're showing the absolute path of files that are
commenting on, we should gracefully handle the case where
there's not enough room to show the entire path on a single
line.

I've opted to put the ellipsis at the beginning of the path
instead of the end because the affected file is the most
important part.