### PR TITLE
Bug 1708817: Adds support for aws_session_token for manual SES testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ send_to=[optional] developer@mail.com
 [email-ses]
 aws_access_key_id=[!] [optional] token
 aws_secret_access_key=[!] [optional] token
+# The aws_session_token is only needed if using credentials that require MFA validation
+# to be accepted. It can be obtained by running:
+# $ aws sts get-session-token --serial-number <serial> --token-code <token>
+# See the docs here: https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html
+aws_session_token=[!] [optional] token
 
 ; this section is for local development options. If "phabricator-emails" sees the "[dev]" header, it will
 ; print logs in plaintext, rather than in JSON, which is far easier for debugging/readability. 

--- a/phabricatoremails/mail.py
+++ b/phabricatoremails/mail.py
@@ -159,6 +159,7 @@ class SesMail:
         send_to: Optional[str],
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
     ):
         """Automatically creates an SES client.
 
@@ -173,6 +174,7 @@ class SesMail:
             "ses",
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
         )
         return cls(client, from_address, logger, send_to)
 

--- a/phabricatoremails/settings.py
+++ b/phabricatoremails/settings.py
@@ -78,8 +78,14 @@ def _parse_mail(config: ConfigParser, logger: Logger):
         aws_secret_access_key = config.get(
             "email-ses", "aws_secret_access_key", fallback=None
         )
+        aws_session_token = config.get("email-ses", "aws_session_token", fallback=None)
         return SesMail.from_aws_credentials(
-            from_address, logger, send_to, aws_access_key_id, aws_secret_access_key
+            from_address,
+            logger,
+            send_to,
+            aws_access_key_id,
+            aws_secret_access_key,
+            aws_session_token,
         )
 
     if implementation == "smtp":

--- a/settings.development-example.ini
+++ b/settings.development-example.ini
@@ -26,6 +26,9 @@ implementation=fs
 
 [email-ses]
 ;send_to=developer@mail.com
+;aws_access_key_id=[!] [optional] token
+;aws_secret_access_key=[!] [optional] token
+;aws_session_token=[!] [optional] token
 
 [dev]
 ;file=example.json

--- a/settings.production-example.ini
+++ b/settings.production-example.ini
@@ -26,5 +26,5 @@ implementation=ses
 temporary_error_retry_delay_seconds=[optional] [default=30]
 
 [email-ses]
-aws_access_key_id=[!] [optional] token
-aws_secret_access_key=[!] [optional] token
+aws_access_key_id=[!] token
+aws_secret_access_key=[!] token


### PR DESCRIPTION
In devservices-dev, making SES requests require MFA-enabled credentials.
These credentials always have a `session_token`, so expose it as a
setting and pipe it through to `boto3`.