### PR TITLE
Bug 1669586: Split "closed" from "landed" event emails

### DIFF
--- a/phabricatoremails/render/events/phabricator.py
+++ b/phabricatoremails/render/events/phabricator.py
@@ -279,8 +279,8 @@ class RevisionCommented:
 
 
 @dataclass
-class RevisionLanded:
-    KIND = "revision-landed"
+class RevisionClosed:
+    KIND = "revision-closed"
     main_comment_message: Optional[CommentMessage]
     inline_comments: list[InlineComment]
     transaction_link: str
@@ -297,6 +297,28 @@ class RevisionLanded:
             Recipient.parse_optional(body.get("author")),
             Recipient.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
+        )
+
+
+@dataclass
+class RevisionLanded:
+    KIND = "revision-landed"
+    author: Optional[Recipient]
+    reviewers: list[Recipient]
+    subscribers: list[Recipient]
+    revision_hash: str
+    hg_link: Optional[str]
+    lando_link: Optional[str]
+
+    @classmethod
+    def parse(cls, body: dict):
+        return cls(
+            Recipient.parse_optional(body.get("author")),
+            Recipient.parse_many(body["reviewers"]),
+            Recipient.parse_many(body["subscribers"]),
+            body["revisionHash"],
+            body.get("hgLink"),
+            body.get("landoLink"),
         )
 
 

--- a/phabricatoremails/render/events/phabricator_secure.py
+++ b/phabricatoremails/render/events/phabricator_secure.py
@@ -125,7 +125,7 @@ class SecureRevisionCommented:
 
 
 @dataclass
-class SecureRevisionLanded:
+class SecureRevisionClosed:
     author: Optional[Recipient]
     reviewers: list[Recipient]
     subscribers: list[Recipient]
@@ -140,6 +140,21 @@ class SecureRevisionLanded:
             Recipient.parse_many(body["subscribers"]),
             body["commentCount"],
             body["transactionLink"],
+        )
+
+
+@dataclass
+class SecureRevisionLanded:
+    author: Optional[Recipient]
+    reviewers: list[Recipient]
+    subscribers: list[Recipient]
+
+    @classmethod
+    def parse(cls, body: dict):
+        return cls(
+            Recipient.parse_optional(body.get("author")),
+            Recipient.parse_many(body["reviewers"]),
+            Recipient.parse_many(body["subscribers"]),
         )
 
 

--- a/phabricatoremails/render/template.py
+++ b/phabricatoremails/render/template.py
@@ -25,6 +25,7 @@ EMOJI = {
     "bell": 0x1F514,
     "building_construction": 0x1F3D7,
     "check_mark": 0x2714,
+    "chequered_flag": 0x1F3C1,
     "circle_arrows": 0x1F504,
     "deny_x": 0x2716,
     "gear": 0x2699,

--- a/phabricatoremails/render/templates/html/public/closed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/closed.html.jinja2
@@ -1,0 +1,30 @@
+{% import '_macros.html.jinja2' as macros %}
+{{ macros.head() }}
+<div class="event-content">
+
+    {% call macros.preview(false, unique_number) %}
+        {{ emoji("chequered_flag") | safe }} {{ actor_name }} closed this revision {{- event | comment_summary }}.
+    {% endcall %}
+
+    {{ macros.title(revision) }}
+
+    <div class="summary">
+        <span class="emoji">{{ emoji("chequered_flag") | safe }}</span>
+        <span class="text"><span><span
+                class="actor">{{ actor_name }}</span> closed this revision {{- event | comment_summary }}</span></span>
+    </div>
+
+    {% if event is commented_on %}
+        {{ macros.comments_link(event.transaction_link) }}
+    {% endif %}
+
+    {% if event.main_comment_message %}
+        {{ macros.main_comment(event.main_comment_message) }}
+    {% endif %}
+
+    {% for comment in event.inline_comments %}
+        {{ macros.inline_comment(comment, recipient_timezone) }}
+    {% endfor %}
+
+    {{ macros.footer(recipient_username, unique_number) }}
+</div>

--- a/phabricatoremails/render/templates/html/public/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/landed.html.jinja2
@@ -3,28 +3,24 @@
 <div class="event-content">
 
     {% call macros.preview(false, unique_number) %}
-        {{ emoji("airplane_arrival") | safe }} {{ actor_name }} landed this revision {{- event | comment_summary }}.
+        {{ emoji("airplane_arrival") | safe }} Revision has landed.
     {% endcall %}
 
     {{ macros.title(revision) }}
 
     <div class="summary">
         <span class="emoji">{{ emoji("airplane_arrival") | safe }}</span>
-        <span class="text"><span><span
-                class="actor">{{ actor_name }}</span> landed this revision {{- event | comment_summary }}</span></span>
+        <span class="text">Revision has landed as <span class="revision">{{ event.revision_hash }}</span></span>
     </div>
 
-    {% if event is commented_on %}
-        {{ macros.comments_link(event.transaction_link) }}
-    {% endif %}
-
-    {% if event.main_comment_message %}
-        {{ macros.main_comment(event.main_comment_message) }}
-    {% endif %}
-
-    {% for comment in event.inline_comments %}
-        {{ macros.inline_comment(comment, recipient_timezone) }}
-    {% endfor %}
+    <div class="revision-landed-link-group">
+        {% if event.hg_link %}
+            <div><a href="{{ event.hg_link }}">View in HG</a></div>
+        {% endif %}
+        {% if event.lando_link %}
+            <div><a href="{{ event.lando_link }}">View in Lando</a></div>
+        {% endif %}
+    </div>
 
     {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/closed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/closed.html.jinja2
@@ -1,0 +1,22 @@
+{% import '_macros.html.jinja2' as macros %}
+{{ macros.head() }}
+<div class="event-content">
+
+    {% call macros.preview(false, unique_number) %}
+        {{ emoji("chequered_flag") | safe }} {{ actor_name }} closed this revision {{- event | secure_comment_summary }}.
+    {% endcall %}
+
+    {{ macros.secure_title(revision) }}
+
+    <div class="summary">
+        <span class="emoji">{{ emoji("chequered_flag") | safe }}</span>
+        <span class="text"><span><span
+                class="actor">{{ actor_name }}</span> closed this revision {{- event | secure_comment_summary }}</span></span>
+    </div>
+
+    {% if event is commented_on_secure %}
+        {{ macros.comments_link(event.transaction_link) }}
+    {% endif %}
+
+    {{ macros.footer(recipient_username, unique_number) }}
+</div>

--- a/phabricatoremails/render/templates/html/secure/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/landed.html.jinja2
@@ -3,20 +3,15 @@
 <div class="event-content">
 
     {% call macros.preview(false, unique_number) %}
-        {{ emoji("airplane_arrival") | safe }} {{ actor_name }} landed this revision {{- event | secure_comment_summary }}.
+        {{ emoji("airplane_arrival") | safe }} Revision has landed.
     {% endcall %}
 
     {{ macros.secure_title(revision) }}
 
     <div class="summary">
         <span class="emoji">{{ emoji("airplane_arrival") | safe }}</span>
-        <span class="text"><span><span
-                class="actor">{{ actor_name }}</span> landed this revision {{- event | secure_comment_summary }}</span></span>
+        <span class="text">Revision has landed</span>
     </div>
-
-    {% if event is commented_on_secure %}
-        {{ macros.comments_link(event.transaction_link) }}
-    {% endif %}
 
     {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/style.css
+++ b/phabricatoremails/render/templates/html/style.css
@@ -85,11 +85,19 @@ div.summary {
     padding-bottom: 5px;
 }
 
-div.event-link {
+.summary .revision {
+    font-family: monospace;
+}
+
+div.event-link, div.revision-landed-link-group {
     margin-top: 4px;
 }
 
-.event-link a[href] {
+.revision-landed-link-group div {
+    margin-top: 4px;
+}
+
+.event-link a[href], .revision-landed-link-group a[href] {
     padding: 6px 10px;
     border-left: 3px solid #464c5c;
     border-radius: 2px;

--- a/phabricatoremails/render/templates/text/public/closed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/closed.text.jinja2
@@ -1,0 +1,9 @@
+{% import '_macros.text.jinja2' as macros %}
+
+{{- macros.revision_info(revision) }}
+
+{{ actor_name }} closed this revision {{- event | comment_summary }}.
+
+{{- macros.main_comment(event.main_comment_message) }}
+{{- macros.inline_comments(event.inline_comments) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/landed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/landed.text.jinja2
@@ -2,8 +2,8 @@
 
 {{- macros.revision_info(revision) }}
 
-{{ actor_name }} landed this revision {{- event | comment_summary }}.
+Revision has landed as {{ event.revision_hash }}.
 
-{{- macros.main_comment(event.main_comment_message) }}
-{{- macros.inline_comments(event.inline_comments) }}
+View in HG:    {{ event.hg_link }}
+View in Lando: {{ event.lando_link }}
 {{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/closed.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/closed.text.jinja2
@@ -2,6 +2,6 @@
 
 {{- macros.secure_revision_info(revision) }}
 
-Revision has landed.
+{{ actor_name }} closed this revision {{- event | secure_comment_summary }}.
 
 {{- macros.footer(recipient_username) }}


### PR DESCRIPTION
There's two different workflows for closing revisions, with different
contexts:
* A user chooses the "close" action within Phabricator, and perhaps
  leaves some comments.
* Phabricator detects that the code associated with the revision has
  landed in the actual VCS repo. In this case, it's useful for email
  recipients to see the revision hash and some relevant links.

This patch splits up the existing "Landed" event to cover both of these
workflows.

Note for reviewers: the "closed" templates are copies of the old
"landed" templates and _have not been modified_. You shouldn't
need to manually review them.