### PR TITLE
Bug 1711755: Remove bell emoji from email preview

### DIFF
--- a/phabricatoremails/render/template.py
+++ b/phabricatoremails/render/template.py
@@ -22,7 +22,6 @@ _DATE_WITH_TIMEZONE_FORMAT = "%b %-d %-I:%M%p"
 EMOJI = {
     "airplane": 0x2708,
     "airplane_arrival": 0x1F6EC,
-    "bell": 0x1F514,
     "building_construction": 0x1F3D7,
     "check_mark": 0x2714,
     "chequered_flag": 0x1F3C1,

--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -4,11 +4,8 @@
     </head>
 {% endmacro %}
 
-{% macro preview(is_actionable, unique_number) %}
+{% macro preview(unique_number) %}
     <div class="preview" aria-hidden="true">
-        {% if is_actionable %}
-            {{ emoji("bell") | safe }}
-        {% endif %}
         {{ caller() }}
 
         {# We want the above preview text to be the only content visible in the "email preview" of Gmail/Mac Mail.

--- a/phabricatoremails/render/templates/html/minimal.html.jinja2
+++ b/phabricatoremails/render/templates/html/minimal.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(true, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("building_construction") | safe }} An action occurred.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/abandoned.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/abandoned.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("airplane") | safe }} {{ actor_name }} abandoned this revision {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/accepted-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/accepted-as-author.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(event.is_ready_to_land, unique_number) %}
+    {% call macros.preview(unique_number) %}
     {{ emoji("check_mark") | safe }} {{ actor_name }} accepted this revision {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/accepted.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/accepted.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("check_mark") | safe }} {{ actor_name }} accepted this revision {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/added-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/added-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }} added you as a reviewer.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/closed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/closed.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("chequered_flag") | safe }} {{ actor_name }} closed this revision {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/commented.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/commented.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("speech_balloon") | safe }} {{ actor_name }} commented on this revision.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/created-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/created-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }} {{ actor_name }} created this revision.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/created.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/created.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }} {{ actor_name }} created this revision.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/edited-metadata-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/edited-metadata-as-reviewer.html.jinja2
@@ -1,7 +1,7 @@
 {% extends "public/edited-metadata.base.html.jinja2" %}
 
 {% block preview %}
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }} edited revision metadata.
     {% endcall %}
 {% endblock %}

--- a/phabricatoremails/render/templates/html/public/edited-metadata.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/edited-metadata.html.jinja2
@@ -1,7 +1,7 @@
 {% extends "public/edited-metadata.base.html.jinja2" %}
 
 {% block preview %}
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }} edited revision metadata.
     {% endcall %}
 {% endblock %}

--- a/phabricatoremails/render/templates/html/public/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/landed.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("airplane_arrival") | safe }} Revision has landed.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/pinged.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/pinged.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(true, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("speech_balloon") | safe }} {{ actor_name }} mentioned you.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/reclaimed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/reclaimed-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("loudspeaker") | safe }}
         {% if reviewer is accepted_reviewer %}
             {{ actor_name }} reclaimed this revision that you've accepted {{- event | comment_summary }}.

--- a/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/reclaimed.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("loudspeaker") | safe }}
         {{ actor_name }} reclaimed this revision {{- event | comment_summary }}.
     {% endcall %}

--- a/phabricatoremails/render/templates/html/public/removed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/removed-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }} removed you as a reviewer.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/requested-changes-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-changes-as-author.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(true, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("wrench") | safe }} {{ actor_name }} requested changes {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/requested-changes.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-changes.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("wrench") | safe }} {{ actor_name }} requested changes {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/requested-review-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-review-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("circle_arrows") | safe }} {{ actor_name }} requested a review {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/requested-review.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/requested-review.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("circle_arrows") | safe }} {{ actor_name }} requested a review {{- event | comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/public/updated-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/updated-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }}
         {% if reviewer is accepted_reviewer %}
             {{ actor_name }} updated this revision that you've accepted.

--- a/phabricatoremails/render/templates/html/public/updated.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/updated.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }}
         {{ actor_name }} updated this revision.
     {% endcall %}

--- a/phabricatoremails/render/templates/html/secure/abandoned.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/abandoned.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("airplane") | safe }} {{ actor_name }} abandoned this revision {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/accepted-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/accepted-as-author.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(event.is_ready_to_land, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("check_mark") | safe }} {{ actor_name }} accepted this revision {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/accepted.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/accepted.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("check_mark") | safe }} {{ actor_name }} accepted this revision {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/added-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/added-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }} added you as a reviewer.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/closed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/closed.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("chequered_flag") | safe }} {{ actor_name }} closed this revision {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/commented.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/commented.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("speech_balloon") | safe }} {{ actor_name }} commented on this revision.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/created-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/created-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }} {{ actor_name }} created this revision.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/created.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/created.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }} {{ actor_name }} created this revision.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/edited-metadata-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/edited-metadata-as-reviewer.html.jinja2
@@ -1,7 +1,7 @@
 {% extends "secure/edited-metadata.base.html.jinja2" %}
 
 {% block preview %}
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }} edited revision metadata.
     {% endcall %}
 {% endblock %}

--- a/phabricatoremails/render/templates/html/secure/edited-metadata.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/edited-metadata.html.jinja2
@@ -1,7 +1,7 @@
 {% extends "secure/edited-metadata.base.html.jinja2" %}
 
 {% block preview %}
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }} edited revision metadata.
     {% endcall %}
 {% endblock %}

--- a/phabricatoremails/render/templates/html/secure/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/landed.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("airplane_arrival") | safe }} Revision has landed.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/pinged.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/pinged.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(true, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("speech_balloon") | safe }} {{ actor_name }} mentioned you.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/reclaimed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/reclaimed-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("loudspeaker") | safe }}
         {% if reviewer is accepted_reviewer %}
             {{ actor_name }} reclaimed this revision that you've accepted {{- event | secure_comment_summary }}.

--- a/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/reclaimed.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("loudspeaker") | safe }}
         {{ actor_name }} reclaimed this revision {{- event | secure_comment_summary }}.
     {% endcall %}

--- a/phabricatoremails/render/templates/html/secure/removed-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/removed-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("memo") | safe }} {{ actor_name }}removed you as a reviewer.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/requested-changes-as-author.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-changes-as-author.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(true, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("wrench") | safe }} {{ actor_name }} requested changes {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/requested-changes.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-changes.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(false, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("wrench") | safe }} {{ actor_name }} requested changes {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/requested-review-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-review-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("circle_arrows") | safe }} {{ actor_name }} requested a review {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/requested-review.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/requested-review.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("circle_arrows") | safe }} {{ actor_name }} requested a review {{- event | secure_comment_summary }}.
     {% endcall %}
 

--- a/phabricatoremails/render/templates/html/secure/updated-as-reviewer.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/updated-as-reviewer.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(reviewer.is_actionable, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }}
         {% if reviewer is accepted_reviewer %}
             {{ actor_name }} updated this revision that you've accepted.

--- a/phabricatoremails/render/templates/html/secure/updated.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/updated.html.jinja2
@@ -2,7 +2,7 @@
 {{ macros.head() }}
 <div class="event-content">
 
-    {% call macros.preview(False, unique_number) %}
+    {% call macros.preview(unique_number) %}
         {{ emoji("keyboard") | safe }}
         {{ actor_name }} updated this revision.
     {% endcall %}


### PR DESCRIPTION
It was difficult to infer that the "bell" preview implied that an
email was actionable.
Additionally, it caused a "�" symbol to appear in collapsed email
previews.

Since the bell was the only usage of the `is_actionable`
parameter from the `preview()` macro, it's been removed.