### PR TITLE
Bug 1711766: Bump libpq-dev apt package version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ LABEL community="https://chat.mozilla.org/#/room/#conduit:mozilla.org"
 LABEL bug-component="https://bugzilla.mozilla.org/enter_bug.cgi?product=Conduit&component=Phabricator"
 
 RUN apt-get update && apt-get install -y \
-    postgresql-client=11+200+deb10u4 \
-    libpq-dev=11.11-0+deb10u1 \
-    gcc=4:8.3.0-1
+    postgresql-client \
+    libpq-dev \
+    gcc
 
 RUN addgroup --gid 10001 app && adduser -q --gecos "" --disabled-password --uid 10001 --gid 10001 --home /app --shell /bin/sh app
 WORKDIR /app


### PR DESCRIPTION
libpq-dev=11.11 no longer exists in the apt repositories, so refer
to the new patch release.