### PR TITLE
Bug 1631868: Show affected repository's name

### DIFF
--- a/phabricatoremails/render/events/phabricator.py
+++ b/phabricatoremails/render/events/phabricator.py
@@ -279,8 +279,8 @@ class RevisionCommented:
 
 
 @dataclass
-class RevisionLanded:
-    KIND = "revision-landed"
+class RevisionClosed:
+    KIND = "revision-closed"
     main_comment_message: Optional[CommentMessage]
     inline_comments: list[InlineComment]
     transaction_link: str
@@ -297,6 +297,28 @@ class RevisionLanded:
             Recipient.parse_optional(body.get("author")),
             Recipient.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
+        )
+
+
+@dataclass
+class RevisionLanded:
+    KIND = "revision-landed"
+    author: Optional[Recipient]
+    reviewers: list[Recipient]
+    subscribers: list[Recipient]
+    revision_hash: str
+    hg_link: Optional[str]
+    lando_link: Optional[str]
+
+    @classmethod
+    def parse(cls, body: dict):
+        return cls(
+            Recipient.parse_optional(body.get("author")),
+            Recipient.parse_many(body["reviewers"]),
+            Recipient.parse_many(body["subscribers"]),
+            body["revisionHash"],
+            body.get("hgLink"),
+            body.get("landoLink"),
         )
 
 

--- a/phabricatoremails/render/events/phabricator.py
+++ b/phabricatoremails/render/events/phabricator.py
@@ -33,6 +33,7 @@ class Revision:
     id: int
     name: str
     link: str
+    repository_name: str
     bug: Optional[Bug]
 
     @classmethod
@@ -41,7 +42,13 @@ class Revision:
         bug = (
             Bug(raw_bug["bugId"], raw_bug["name"], raw_bug["link"]) if raw_bug else None
         )
-        return cls(revision["revisionId"], revision["name"], revision["link"], bug)
+        return cls(
+            revision["revisionId"],
+            revision["name"],
+            revision["link"],
+            revision["repositoryName"],
+            bug,
+        )
 
 
 @dataclass

--- a/phabricatoremails/render/events/phabricator_secure.py
+++ b/phabricatoremails/render/events/phabricator_secure.py
@@ -125,7 +125,7 @@ class SecureRevisionCommented:
 
 
 @dataclass
-class SecureRevisionLanded:
+class SecureRevisionClosed:
     author: Optional[Recipient]
     reviewers: list[Recipient]
     subscribers: list[Recipient]
@@ -140,6 +140,21 @@ class SecureRevisionLanded:
             Recipient.parse_many(body["subscribers"]),
             body["commentCount"],
             body["transactionLink"],
+        )
+
+
+@dataclass
+class SecureRevisionLanded:
+    author: Optional[Recipient]
+    reviewers: list[Recipient]
+    subscribers: list[Recipient]
+
+    @classmethod
+    def parse(cls, body: dict):
+        return cls(
+            Recipient.parse_optional(body.get("author")),
+            Recipient.parse_many(body["reviewers"]),
+            Recipient.parse_many(body["subscribers"]),
         )
 
 

--- a/phabricatoremails/render/template.py
+++ b/phabricatoremails/render/template.py
@@ -25,6 +25,7 @@ EMOJI = {
     "bell": 0x1F514,
     "building_construction": 0x1F3D7,
     "check_mark": 0x2714,
+    "chequered_flag": 0x1F3C1,
     "circle_arrows": 0x1F504,
     "deny_x": 0x2716,
     "gear": 0x2699,

--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -37,6 +37,9 @@
                 <a href="{{ revision.bug.link }}">bug {{ revision.bug.id }}: {{ revision.bug.name }}</a>
             </div>
         {% endif %}
+        <div class="repository">
+            For repository <span class="repository-name">{{ revision.repository_name }}</span>
+        </div>
     </div>
 {% endmacro %}
 

--- a/phabricatoremails/render/templates/html/public/closed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/closed.html.jinja2
@@ -1,0 +1,30 @@
+{% import '_macros.html.jinja2' as macros %}
+{{ macros.head() }}
+<div class="event-content">
+
+    {% call macros.preview(false, unique_number) %}
+        {{ emoji("chequered_flag") | safe }} {{ actor_name }} closed this revision {{- event | comment_summary }}.
+    {% endcall %}
+
+    {{ macros.title(revision) }}
+
+    <div class="summary">
+        <span class="emoji">{{ emoji("chequered_flag") | safe }}</span>
+        <span class="text"><span><span
+                class="actor">{{ actor_name }}</span> closed this revision {{- event | comment_summary }}</span></span>
+    </div>
+
+    {% if event is commented_on %}
+        {{ macros.comments_link(event.transaction_link) }}
+    {% endif %}
+
+    {% if event.main_comment_message %}
+        {{ macros.main_comment(event.main_comment_message) }}
+    {% endif %}
+
+    {% for comment in event.inline_comments %}
+        {{ macros.inline_comment(comment, recipient_timezone) }}
+    {% endfor %}
+
+    {{ macros.footer(recipient_username, unique_number) }}
+</div>

--- a/phabricatoremails/render/templates/html/public/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/public/landed.html.jinja2
@@ -3,28 +3,24 @@
 <div class="event-content">
 
     {% call macros.preview(false, unique_number) %}
-        {{ emoji("airplane_arrival") | safe }} {{ actor_name }} landed this revision {{- event | comment_summary }}.
+        {{ emoji("airplane_arrival") | safe }} Revision has landed.
     {% endcall %}
 
     {{ macros.title(revision) }}
 
     <div class="summary">
         <span class="emoji">{{ emoji("airplane_arrival") | safe }}</span>
-        <span class="text"><span><span
-                class="actor">{{ actor_name }}</span> landed this revision {{- event | comment_summary }}</span></span>
+        <span class="text">Revision has landed as <span class="revision">{{ event.revision_hash }}</span></span>
     </div>
 
-    {% if event is commented_on %}
-        {{ macros.comments_link(event.transaction_link) }}
-    {% endif %}
-
-    {% if event.main_comment_message %}
-        {{ macros.main_comment(event.main_comment_message) }}
-    {% endif %}
-
-    {% for comment in event.inline_comments %}
-        {{ macros.inline_comment(comment, recipient_timezone) }}
-    {% endfor %}
+    <div class="revision-landed-link-group">
+        {% if event.hg_link %}
+            <div><a href="{{ event.hg_link }}">View in HG</a></div>
+        {% endif %}
+        {% if event.lando_link %}
+            <div><a href="{{ event.lando_link }}">View in Lando</a></div>
+        {% endif %}
+    </div>
 
     {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/secure/closed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/closed.html.jinja2
@@ -1,0 +1,22 @@
+{% import '_macros.html.jinja2' as macros %}
+{{ macros.head() }}
+<div class="event-content">
+
+    {% call macros.preview(false, unique_number) %}
+        {{ emoji("chequered_flag") | safe }} {{ actor_name }} closed this revision {{- event | secure_comment_summary }}.
+    {% endcall %}
+
+    {{ macros.secure_title(revision) }}
+
+    <div class="summary">
+        <span class="emoji">{{ emoji("chequered_flag") | safe }}</span>
+        <span class="text"><span><span
+                class="actor">{{ actor_name }}</span> closed this revision {{- event | secure_comment_summary }}</span></span>
+    </div>
+
+    {% if event is commented_on_secure %}
+        {{ macros.comments_link(event.transaction_link) }}
+    {% endif %}
+
+    {{ macros.footer(recipient_username, unique_number) }}
+</div>

--- a/phabricatoremails/render/templates/html/secure/landed.html.jinja2
+++ b/phabricatoremails/render/templates/html/secure/landed.html.jinja2
@@ -3,20 +3,15 @@
 <div class="event-content">
 
     {% call macros.preview(false, unique_number) %}
-        {{ emoji("airplane_arrival") | safe }} {{ actor_name }} landed this revision {{- event | secure_comment_summary }}.
+        {{ emoji("airplane_arrival") | safe }} Revision has landed.
     {% endcall %}
 
     {{ macros.secure_title(revision) }}
 
     <div class="summary">
         <span class="emoji">{{ emoji("airplane_arrival") | safe }}</span>
-        <span class="text"><span><span
-                class="actor">{{ actor_name }}</span> landed this revision {{- event | secure_comment_summary }}</span></span>
+        <span class="text">Revision has landed</span>
     </div>
-
-    {% if event is commented_on_secure %}
-        {{ macros.comments_link(event.transaction_link) }}
-    {% endif %}
 
     {{ macros.footer(recipient_username, unique_number) }}
 </div>

--- a/phabricatoremails/render/templates/html/style.css
+++ b/phabricatoremails/render/templates/html/style.css
@@ -85,11 +85,19 @@ div.summary {
     padding-bottom: 5px;
 }
 
-div.event-link {
+.summary .revision {
+    font-family: monospace;
+}
+
+div.event-link, div.revision-landed-link-group {
     margin-top: 4px;
 }
 
-.event-link a[href] {
+.revision-landed-link-group div {
+    margin-top: 4px;
+}
+
+.event-link a[href], .revision-landed-link-group a[href] {
     padding: 6px 10px;
     border-left: 3px solid #464c5c;
     border-radius: 2px;

--- a/phabricatoremails/render/templates/html/style.css
+++ b/phabricatoremails/render/templates/html/style.css
@@ -35,7 +35,7 @@ a[href].revision {
     margin-bottom: 0.2em;
 }
 
-.bug {
+.bug, .repository {
     color: #000;
     font-size: 13px;
     font-style: italic;
@@ -43,6 +43,10 @@ a[href].revision {
 
 .bug a[href] {
     color: #5b75a5;
+}
+
+.repository-name {
+    font-weight: bold;
 }
 
 div.summary {

--- a/phabricatoremails/render/templates/text/_macros.text.jinja2
+++ b/phabricatoremails/render/templates/text/_macros.text.jinja2
@@ -1,5 +1,6 @@
 {% macro revision_info(revision) %}
 {{- revision.link }}
+Repository: {{ revision.repository_name }}
 {%- if revision.bug %}
 
 (Associated with bug {{ revision.bug.id }}: {{ revision.bug.name }})

--- a/phabricatoremails/render/templates/text/public/closed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/closed.text.jinja2
@@ -1,0 +1,9 @@
+{% import '_macros.text.jinja2' as macros %}
+
+{{- macros.revision_info(revision) }}
+
+{{ actor_name }} closed this revision {{- event | comment_summary }}.
+
+{{- macros.main_comment(event.main_comment_message) }}
+{{- macros.inline_comments(event.inline_comments) }}
+{{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/public/landed.text.jinja2
+++ b/phabricatoremails/render/templates/text/public/landed.text.jinja2
@@ -2,8 +2,8 @@
 
 {{- macros.revision_info(revision) }}
 
-{{ actor_name }} landed this revision {{- event | comment_summary }}.
+Revision has landed as {{ event.revision_hash }}.
 
-{{- macros.main_comment(event.main_comment_message) }}
-{{- macros.inline_comments(event.inline_comments) }}
+View in HG:    {{ event.hg_link }}
+View in Lando: {{ event.lando_link }}
 {{- macros.footer(recipient_username) }}

--- a/phabricatoremails/render/templates/text/secure/closed.text.jinja2
+++ b/phabricatoremails/render/templates/text/secure/closed.text.jinja2
@@ -2,6 +2,6 @@
 
 {{- macros.secure_revision_info(revision) }}
 
-Revision has landed.
+{{ actor_name }} closed this revision {{- event | secure_comment_summary }}.
 
 {{- macros.footer(recipient_username) }}

--- a/tests/render/test_mailbatch.py
+++ b/tests/render/test_mailbatch.py
@@ -16,7 +16,7 @@ from tests.render.mock_template import MockTemplateStore
 
 ACTOR = Actor("actor", "actor")
 NON_ACTOR_RECIPIENT = Recipient("1@mail", "1", timezone.utc, False)
-PUBLIC_REVISION = Revision(1, "revision", "link", None)
+PUBLIC_REVISION = Revision(1, "revision", "link", "repo", None)
 EVENT = RevisionCreated([], [], [])
 
 

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -35,7 +35,12 @@ def _create_public_context(revision_id: int = 1):
         "eventKind": RevisionUpdated.KIND,
         "actor": {"userName": "actor", "realName": "actor"},
         "actorName": "actor",
-        "revision": {"revisionId": revision_id, "name": "revision", "link": "link"},
+        "revision": {
+            "revisionId": revision_id,
+            "name": "revision",
+            "repositoryName": "repo",
+            "link": "link",
+        },
         "body": BODY,
     }
 
@@ -48,6 +53,7 @@ def _create_secure_context(revision_id: int, bug_id: int):
             "revisionId": revision_id,
             "name": "revision",
             "link": "link",
+            "repositoryName": "repo",
             "bug": {"bugId": bug_id, "link": "link"},
         },
         "body": BODY,

--- a/tests/render/test_template.py
+++ b/tests/render/test_template.py
@@ -53,7 +53,7 @@ def test_integration_templates():
 
     html, text = template.render(
         {
-            "revision": Revision(1, "revision", "link", None),
+            "revision": Revision(1, "revision", "link", "repo", None),
             "actor_name": "actor",
             "recipient_username": "1",
             "unique_number": 0,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -91,6 +91,7 @@ def test_integration_pipeline():
                         },
                         "revision": {
                             "revisionId": 1,
+                            "repositoryName": "repo",
                             "link": "link",
                             "bug": {"bugId": 1, "link": "link"},
                         },
@@ -136,7 +137,12 @@ def test_integration_pipeline():
                             ],
                             "transactionLink": "link",
                         },
-                        "revision": {"revisionId": 2, "name": "name 2", "link": "link"},
+                        "revision": {
+                            "revisionId": 2,
+                            "name": "name 2",
+                            "repositoryName": "repo",
+                            "link": "link",
+                        },
                     },
                 ],
             },


### PR DESCRIPTION
Tucks the repository name underneath the bug (if it exists) or the
revision name.

-----

I'm not super happy with the design here, but I wanted to ship something without bike-shedding too far.
I feel that the bold repo name is too visually similar to the bold actor name, which is very spacially close. Unsure the best way to fix this - I tried making a light background around the repo name with round borders, but it was too busy. Time to :ship: 

With bug:
![Screenshot from 2021-05-19 15-00-18](https://user-images.githubusercontent.com/7784737/118869931-00160800-b8b4-11eb-957b-690652e465b3.png)

Without bug:
![Screenshot from 2021-05-19 15-02-39](https://user-images.githubusercontent.com/7784737/118869952-04dabc00-b8b4-11eb-96e9-5b9c86225c03.png)
