### PR TITLE
Bug 1711964: Consider most AWS errors as not caused by the outgoing mail

### DIFF
--- a/phabricatoremails/mail.py
+++ b/phabricatoremails/mail.py
@@ -209,22 +209,8 @@ class SesMail:
                 SendEmailState.TEMPORARY_FAILURE, type(error).__name__, error
             )
         except botocore.exceptions.ClientError as error:
-            # Potential error list fetched from
+            # Potential error list determined from hand-testing and the docs:
             # https://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html#API_SendRawEmail_Errors  # noqa
             error_code = error.response["Error"]["Code"]
-            if error_code in (
-                "AccountSendingPausedException",
-                "ConfigurationSetDoesNotExist",
-                "ConfigurationSetSendingPausedException",
-                "MailFromDomainNotVerifiedException",
-            ):
-                return SendEmailResult(
-                    SendEmailState.TEMPORARY_FAILURE, error_code, error
-                )
-            else:
-                # If this is "MessageRejected" or some other unexpected Amazon error,
-                # then pass it upwards as a permanent error.
-                return SendEmailResult(
-                    SendEmailState.PERMANENT_FAILURE, error_code, error
-                )
+            return SendEmailResult(SendEmailState.TEMPORARY_FAILURE, error_code, error)
         return SendEmailResult(SendEmailState.SUCCESS)


### PR DESCRIPTION
We only want to bubble up "permanent error" and skip an outgoing message
if the message itself is causing the failure.
However, all SES errors that I'm currently aware of either directly
or potentially caused by configuration issues and *not* the message.

My original assumption of `MessageRejected` referring to issues with
the message was proved incorrect by this official document:
https://aws.amazon.com/premiumsupport/knowledge-center/ses-554-400-message-rejected-error/