### PR TITLE
Bug 1715109: Wrap "From" header in double-quotes

### DIFF
--- a/phabricatoremails/mail.py
+++ b/phabricatoremails/mail.py
@@ -50,7 +50,7 @@ class OutgoingEmail:
     def encode_from(self, from_address):
         if self.actor:
             actor_header = Header(f"{self.actor.user_name} ({self.actor.real_name})")
-            return f"{actor_header.encode()} <{from_address}>"
+            return f'"{actor_header.encode()}" <{from_address}>'
         else:
             return from_address
 


### PR DESCRIPTION
Without the double-quotes, email clients
parse the "From" header differently. This
causes symptoms such as GMail only showing
the `username` part of the header without
the attached `(Real Name)`.

Before:
![Screenshot from 2021-06-07 16-53-49](https://user-images.githubusercontent.com/7784737/121086368-0f042200-c7b1-11eb-98b8-1524b327b679.png)

After (don't mind the different data, it's coming from DEV instead of PROD):
![Screenshot from 2021-06-07 16-54-14](https://user-images.githubusercontent.com/7784737/121086393-14616c80-c7b1-11eb-84fe-b3d7b632e807.png)
