### PR TITLE
Bug 1674796: Use threading headers

### DIFF
--- a/phabricatoremails/render/mailbatch.py
+++ b/phabricatoremails/render/mailbatch.py
@@ -80,6 +80,7 @@ class MailBatch:
         recipient_address: str,
         timestamp: int,
         actor: Actor,
+        revision_id: int,
         template_params: dict,
     ):
         """Render the provided template and parameters into an OutgoingEmail."""
@@ -90,6 +91,7 @@ class MailBatch:
             subject,
             recipient_address,
             timestamp,
+            revision_id,
             html_email,
             text_email,
             actor,
@@ -113,6 +115,7 @@ class MailBatch:
                 recipient_address=target.recipient_email,
                 actor=actor,
                 timestamp=timestamp,
+                revision_id=revision.id,
                 template_params={
                     "revision": revision,
                     "actor_name": actor.user_name,
@@ -144,6 +147,7 @@ class MailBatch:
                 recipient_address=target.recipient_email,
                 actor=actor,
                 timestamp=timestamp,
+                revision_id=revision.id,
                 template_params={
                     "revision": revision,
                     "actor_name": actor.user_name,

--- a/phabricatoremails/render/render.py
+++ b/phabricatoremails/render/render.py
@@ -250,6 +250,7 @@ class Render:
                     f"D{revision.id}",
                     recipient.email,
                     timestamp,
+                    revision.id,
                     html_email,
                     text_email,
                 )

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -19,6 +19,7 @@ MOCK_EMAIL = OutgoingEmail(
     "phabricator subject",
     "to@mail",
     0,
+    1,
     "summary in html",
     "summary in text",
 )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -359,14 +359,14 @@ def test_retries_temporary_email_failures(_):
         mail,
         Mock(),
         logging.create_dev_logger(),
-        [OutgoingEmail("", "", "", 0, "", "")],
+        [OutgoingEmail("", "", "", 0, 1, "", "")],
         0,
     )
     _send_emails(
         mail,
         Mock(),
         logging.create_dev_logger(),
-        [OutgoingEmail("", "", "", 1, "", "")],
+        [OutgoingEmail("", "", "", 1, 1, "", "")],
         0,
     )
     assert mail.call_count == 3


### PR DESCRIPTION
Provide four threading headers: `In-Reply-To`, `References`,
`Thread-Topic` and `Thread-Index`.

The implementation of headers here is verify similar to the behaviour of
Phabricator revision email headers.

Note that an "imaginary" top-level message ID was used instead of
referring to the "first message" in each thread because each user may
have a different "first message", and tracking that information would've
been nontrivial. Fortunately, email clients are resilient to grouping by
"imaginary parent", so this tradeoff should be acceptable.