### PR TITLE
Bug 1717771: Use relative font sizing

### DIFF
--- a/phabricatoremails/render/templates/html/style.css
+++ b/phabricatoremails/render/templates/html/style.css
@@ -24,8 +24,8 @@ div.preview, div.end-preview {
 }
 
 .title {
-    font-size: 16px;
-    line-height: 16px;
+    font-size: 1.3em;
+    line-height: 1.0;
     margin-bottom: 0.2em;
 }
 
@@ -37,7 +37,8 @@ a[href].revision {
 
 .bug, .repository {
     color: #000;
-    font-size: 13px;
+    font-size: 0.75em;
+    line-height: 1.1;
     font-style: italic;
 }
 
@@ -64,8 +65,7 @@ div.summary {
     padding: 8px 12px;
     background-color: #f3f5f7;
     border-radius: 2px;
-    /*line-height: 18px;*/
-    font-size: 14px;
+    font-size: 1.1em;
     display: table-cell;
     vertical-align: middle;
 }
@@ -91,6 +91,7 @@ div.summary {
 
 .summary .revision {
     font-family: monospace;
+    font-size: 1.3em;
 }
 
 div.event-link, div.revision-landed-link-group {
@@ -106,14 +107,13 @@ div.event-link, div.revision-landed-link-group {
     border-left: 3px solid #464c5c;
     border-radius: 2px;
     color: #464c5c;
-    font-size: 16px;
+    font-size: 1.2em;
     font-weight: bold;
     background-color: #f3f5f7;
     display: inline-block;
 }
 
 .changes-title {
-    font-size: 14px;
     font-weight: bold;
     margin-bottom: 0.5em;
 }
@@ -128,7 +128,7 @@ table td:first-child {
 }
 
 .reviewers, .metadata-changes, .affected-files {
-    font-size: 14px;
+    font-size: 1.1em;
     color: #464c5c;
 }
 
@@ -263,6 +263,7 @@ table td:first-child {
 
 .affected-files pre {
     margin: 0;
+    font-size: 1.3em;
 }
 
 blockquote {
@@ -279,7 +280,7 @@ blockquote {
     /* the !important here is to override Android's "padding-left: 0 !important" for blockquotes that we don't want */
     padding: 8px 12px !important;
     color: #464c5c;
-    font-size: 14px;
+    font-size: 1.1em;
     border-radius: 2px;
 }
 
@@ -294,10 +295,14 @@ blockquote {
 }
 
 .inline-comment {
-    font-size: 14px;
+    font-size: 1.1em;
     overflow: hidden;
     border: 1px solid #d8d8d8;
     border-radius: 2px;
+}
+
+.inline-comment > .comment {
+    font-size: inherit;
 }
 
 .inline-comment > a[href] {
@@ -412,11 +417,12 @@ except with some adjustments to make them "fit better" with our custom style.
 
 .message .remarkup-monospaced, .message .remarkup-code {
     background-color: rgba(71, 87, 120, 0.08);
+    font-size: 1.3em;
 }
 
 .message .remarkup-code {
-    font-size: 11px;
-    line-height: 15px;
+    font-size: 0.9em;
+    line-height: 1.3;
     padding: 12px;
 }
 
@@ -426,7 +432,7 @@ except with some adjustments to make them "fit better" with our custom style.
     background: #bfcfda;
     margin: 12px 0;
     word-break: normal;
-    line-height: 1.7em;
+    line-height: 1.7;
     color: inherit;
 }
 
@@ -452,8 +458,8 @@ except with some adjustments to make them "fit better" with our custom style.
 
 .code td {
     font: inherit;
-    font-size: 11px;
-    line-height: 15px;
+    font-size: 0.9em;
+    line-height: 1.3;
 }
 
 .line-number {
@@ -476,6 +482,7 @@ except with some adjustments to make them "fit better" with our custom style.
 
 .src pre {
     margin: 0;
+    font-size: 1.3em;
 }
 
 .no-change-line .line-number {
@@ -515,7 +522,7 @@ except with some adjustments to make them "fit better" with our custom style.
 div.footer {
     border-top: 1px solid #d8d8d8;
     color: #464c5c;
-    font-size: 13px;
+    font-size: 0.9em;
     font-style: italic;
     padding-top: 8px;
     margin-top: 10px;


### PR DESCRIPTION
To support various font-size settings in different email
clients, we should use relative font sizes.

* We can't use `rem` because GMail doesn't use an iframe,
  so `rem` is the base text size for regular non-mail content.
  So, we have to chain `em` to have sizes be relative to the
  provided font-size at the mail level.
* `line-height` must be relative as well. Additionally,
  it sounds like it's preferred to omit the `em` postfix,
  and to instead just have a number, e.g.: `1.2`. Works for me.
* Since we can't use `rem`, each `em` declaration scales based
  on inherited values. That means that this patch has some
  risk that an unlucky `font-size` chain may have cause
  a regression in UI. However, I'll manage this by hand-testing
  the majority of different email events to try to suss out
  such potential regressions.
* I've left stylistic decisions like padding, margin,
  border-radius, etc. to still be px-based. This makes scaled
  content look a _little_ goofy, but I think it's a good
  trade-off.