### PR TITLE
Bug 1719928: "View Inline" link should be right-aligned

### DIFF
--- a/phabricatoremails/render/templates/html/_macros.html.jinja2
+++ b/phabricatoremails/render/templates/html/_macros.html.jinja2
@@ -92,8 +92,10 @@
 {% macro inline_comment(comment, recipient_timezone) %}
     <div class="inline-comment">
         <a href="{{ comment.link }}">
-            <span class="file-context"><span>{{ comment.file_context }}</span></span>
-            <span class="view-inline">View inline</span>
+            <div class="view-inline-container">
+                <span class="file-context"><span>{{ comment.file_context }}</span></span>
+                <span class="view-inline">View inline</span>
+            </div>
         </a>
         {% if comment.context is reply %}
             <div class="comment">

--- a/phabricatoremails/render/templates/html/style.css
+++ b/phabricatoremails/render/templates/html/style.css
@@ -301,15 +301,30 @@ blockquote {
 }
 
 .inline-comment > a[href] {
-    display: flex;
+    display: block;
     border-bottom: 1px solid #d8d8d8;
     color: #464c5c;
     padding: 4px 8px;
     text-decoration: none;
 }
 
-.inline-comment .file-context {
-    flex-grow: 1;
+.inline-comment .view-inline-container {
+    display: inline-table;
+}
+
+.view-inline-container .file-context {
+    /* Not all email clients support CSS Flex.
+       So, to make the file context "grow" as
+       much as possible, we make the parent
+       "display: table" and we make this
+       fake cell have "width: 100%".
+       "max-width: 0;" is needed for overflow
+       ellipsis to work.
+       A hack, but it does its job. */
+    display: table-cell;
+    width: 100%;
+    max-width: 0;
+
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -319,13 +334,14 @@ blockquote {
     text-align: left;
 }
 
-.inline-comment .file-context > span {
+.view-inline-container .file-context > span {
     /* Resolve "direction: rtl" changing the position of slashes */
     unicode-bidi: plaintext;
 }
 
-.inline-comment .view-inline {
-    margin-left: 20px;
+.view-inline-container .view-inline {
+    display: table-cell;
+    padding-left: 20px;
     text-decoration: underline;
     white-space: nowrap;
 }


### PR DESCRIPTION
Flex properties are filtered out by GMail, which makes sense
since not all mail clients may support modern CSS properties.
So, we need to use a table-cell hack to right-align our "View Inline"
link while also ellipsis-ing the filename when there's not enough room.