### PR TITLE
Bug 2012089 - Phabricator email reviewer stamps sometimes show all group members instead of group as reviewer

### DIFF
--- a/phabricatoremails/render/events/phabricator.py
+++ b/phabricatoremails/render/events/phabricator.py
@@ -187,7 +187,7 @@ class RevisionAbandoned:
     main_comment_message: Optional[CommentMessage]
     inline_comments: list[InlineComment]
     transaction_link: str
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
 
     @classmethod
@@ -196,7 +196,7 @@ class RevisionAbandoned:
             CommentMessage.parse_optional(body.get("mainCommentMessage")),
             InlineComment.parse_many(body["inlineComments"]),
             body["transactionLink"],
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
         )
 
@@ -246,7 +246,7 @@ class RevisionAccepted:
     lando_link: Optional[str]
     is_ready_to_land: bool
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
 
     @classmethod
@@ -258,7 +258,7 @@ class RevisionAccepted:
             body.get("landoLink"),
             body["isReadyToLand"],
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
         )
 
@@ -270,7 +270,7 @@ class RevisionCommented:
     inline_comments: list[InlineComment]
     transaction_link: str
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
 
     @classmethod
@@ -280,7 +280,7 @@ class RevisionCommented:
             InlineComment.parse_many(body["inlineComments"]),
             body["transactionLink"],
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
         )
 
@@ -292,7 +292,7 @@ class RevisionClosed:
     inline_comments: list[InlineComment]
     transaction_link: str
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
 
     @classmethod
@@ -302,7 +302,7 @@ class RevisionClosed:
             InlineComment.parse_many(body["inlineComments"]),
             body["transactionLink"],
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
         )
 
@@ -311,7 +311,7 @@ class RevisionClosed:
 class RevisionLanded:
     KIND = "revision-landed"
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
     revision_hash: str
     hg_link: Optional[str]
@@ -321,7 +321,7 @@ class RevisionLanded:
     def parse(cls, body: dict):
         return cls(
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
             body["revisionHash"],
             body.get("hgLink"),
@@ -354,7 +354,7 @@ class RevisionRequestedChanges:
     inline_comments: list[InlineComment]
     transaction_link: str
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
 
     @classmethod
@@ -364,7 +364,7 @@ class RevisionRequestedChanges:
             InlineComment.parse_many(body["inlineComments"]),
             body["transactionLink"],
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
         )
 

--- a/phabricatoremails/render/events/phabricator_secure.py
+++ b/phabricatoremails/render/events/phabricator_secure.py
@@ -39,7 +39,7 @@ class SecureRevision:
 
 @dataclass
 class SecureRevisionAbandoned:
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
     comment_count: int
     transaction_link: str
@@ -47,7 +47,7 @@ class SecureRevisionAbandoned:
     @classmethod
     def parse(cls, body: dict):
         return cls(
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
             body["commentCount"],
             body["transactionLink"],
@@ -89,7 +89,7 @@ class SecureRevisionAccepted:
     lando_link: Optional[str]
     is_ready_to_land: bool
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
     comment_count: int
     transaction_link: str
@@ -100,7 +100,7 @@ class SecureRevisionAccepted:
             body.get("landoLink"),
             body["isReadyToLand"],
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
             body["commentCount"],
             body["transactionLink"],
@@ -110,7 +110,7 @@ class SecureRevisionAccepted:
 @dataclass
 class SecureRevisionCommented:
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
     transaction_link: str
 
@@ -118,7 +118,7 @@ class SecureRevisionCommented:
     def parse(cls, body: dict):
         return cls(
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
             body["transactionLink"],
         )
@@ -127,7 +127,7 @@ class SecureRevisionCommented:
 @dataclass
 class SecureRevisionClosed:
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
     comment_count: int
     transaction_link: str
@@ -136,7 +136,7 @@ class SecureRevisionClosed:
     def parse(cls, body: dict):
         return cls(
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
             body["commentCount"],
             body["transactionLink"],
@@ -146,14 +146,14 @@ class SecureRevisionClosed:
 @dataclass
 class SecureRevisionLanded:
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
 
     @classmethod
     def parse(cls, body: dict):
         return cls(
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
         )
 
@@ -174,7 +174,7 @@ class SecureRevisionCommentPinged:
 @dataclass
 class SecureRevisionRequestedChanges:
     author: Optional[Recipient]
-    reviewers: list[Recipient]
+    reviewers: list[Reviewer]
     subscribers: list[Recipient]
     comment_count: int
     transaction_link: str
@@ -183,7 +183,7 @@ class SecureRevisionRequestedChanges:
     def parse(cls, body: dict):
         return cls(
             Recipient.parse_optional(body.get("author")),
-            Recipient.parse_many(body["reviewers"]),
+            Reviewer.parse_many(body["reviewers"]),
             Recipient.parse_many(body["subscribers"]),
             body["commentCount"],
             body["transactionLink"],

--- a/phabricatoremails/render/render.py
+++ b/phabricatoremails/render/render.py
@@ -68,7 +68,8 @@ def parse_body(kind: str, is_secure: bool, raw_body: dict, batch: MailBatch):
             body = RevisionAccepted.parse(raw_body)
 
         batch.target(body.author, "accepted-as-author")
-        batch.target_many(body.reviewers, "accepted")
+        for reviewer in body.reviewers:
+            batch.target_many(reviewer.recipients, "accepted")
         batch.target_many(body.subscribers, "accepted")
     elif kind == RevisionMetadataEdited.KIND:
         # There's no "insecure" variant for when metadata is edited
@@ -96,7 +97,8 @@ def parse_body(kind: str, is_secure: bool, raw_body: dict, batch: MailBatch):
             body = RevisionCommented.parse(raw_body)
 
         batch.target(body.author, "commented")
-        batch.target_many(body.reviewers, "commented")
+        for reviewer in body.reviewers:
+            batch.target_many(reviewer.recipients, "commented")
         batch.target_many(body.subscribers, "commented")
     elif kind == RevisionClosed.KIND or _is_legacy_revision_landed(kind, raw_body):
         if is_secure:
@@ -104,7 +106,8 @@ def parse_body(kind: str, is_secure: bool, raw_body: dict, batch: MailBatch):
         else:
             body = RevisionClosed.parse(raw_body)
         batch.target(body.author, "closed")
-        batch.target_many(body.reviewers, "closed")
+        for reviewer in body.reviewers:
+            batch.target_many(reviewer.recipients, "closed")
         batch.target_many(body.subscribers, "closed")
     elif kind == RevisionLanded.KIND:
         if is_secure:
@@ -112,7 +115,8 @@ def parse_body(kind: str, is_secure: bool, raw_body: dict, batch: MailBatch):
         else:
             body = RevisionLanded.parse(raw_body)
         batch.target(body.author, "landed")
-        batch.target_many(body.reviewers, "landed")
+        for reviewer in body.reviewers:
+            batch.target_many(reviewer.recipients, "landed")
         batch.target_many(body.subscribers, "landed")
     elif kind == RevisionCommentPinged.KIND:
         if is_secure:
@@ -127,7 +131,8 @@ def parse_body(kind: str, is_secure: bool, raw_body: dict, batch: MailBatch):
             body = RevisionRequestedChanges.parse(raw_body)
 
         batch.target(body.author, "requested-changes-as-author")
-        batch.target_many(body.reviewers, "requested-changes")
+        for reviewer in body.reviewers:
+            batch.target_many(reviewer.recipients, "requested-changes")
         batch.target_many(body.subscribers, "requested-changes")
     elif kind == RevisionRequestedReview.KIND:
         if is_secure:
@@ -156,7 +161,8 @@ def parse_body(kind: str, is_secure: bool, raw_body: dict, batch: MailBatch):
             body = SecureRevisionAbandoned.parse(raw_body)
         else:
             body = RevisionAbandoned.parse(raw_body)
-        batch.target_many(body.reviewers, "abandoned")
+        for reviewer in body.reviewers:
+            batch.target_many(reviewer.recipients, "abandoned")
         batch.target_many(body.subscribers, "abandoned")
     elif kind == RevisionReclaimed.KIND:
         if is_secure:

--- a/tests/mock_worker.py
+++ b/tests/mock_worker.py
@@ -8,7 +8,7 @@ class MockWorker:
     def set_initial_position(
         self, query_position_store: QueryPositionStore, position: int
     ) -> int:
-        pass
+        return position
 
     def process(self, db, pipeline_callback) -> None:
         pass

--- a/tests/render/test_template.py
+++ b/tests/render/test_template.py
@@ -237,7 +237,9 @@ def test_generate_phab_stamps_for_requested_changes_with_groups():
     member1 = Recipient("m1@example.com", "member1", timezone.utc, False)
     member2 = Recipient("m2@example.com", "member2", timezone.utc, False)
 
-    revision = Revision(279938, "D279938", "http://example.com/D279938", "firefox-autoland", None)
+    revision = Revision(
+        279938, "D279938", "http://example.com/D279938", "firefox-autoland", None
+    )
     actor = Actor(user_name="gregtatum", real_name="Greg Tatum")
 
     individual_reviewer = Reviewer(
@@ -264,11 +266,12 @@ def test_generate_phab_stamps_for_requested_changes_with_groups():
 
     stamps = generate_phab_stamps(revision, actor, event)
 
-    assert "reviewer(@bgrins)" in stamps    # individual gets @
+    assert "reviewer(@bgrins)" in stamps  # individual gets @
     assert "reviewer(#some-team)" in stamps  # group gets #
     # group members must NOT appear as individual reviewer stamps
     assert "reviewer(@member1)" not in stamps
     assert "reviewer(@member2)" not in stamps
+
 
 def test_generate_phab_stamps_with_regular_reviewer():
     """Test that generate_phab_stamps handles regular Reviewer objects correctly.

--- a/tests/render/test_template.py
+++ b/tests/render/test_template.py
@@ -242,11 +242,12 @@ def test_generate_phab_stamps_for_requested_changes_with_groups():
     )
     actor = Actor(user_name="gregtatum", real_name="Greg Tatum")
 
+    bgrins = Recipient("bgrins@example.com", "bgrins", timezone.utc, False)
     individual_reviewer = Reviewer(
         name="bgrins",
         is_actionable=False,
         status=ReviewerStatus.REQUESTED_CHANGES,
-        recipients=[member1],
+        recipients=[bgrins],
     )
     group_reviewer = Reviewer(
         name="some-team",

--- a/tests/render/test_template.py
+++ b/tests/render/test_template.py
@@ -18,6 +18,7 @@ from phabricatoremails.render.events.common import (
 )
 from phabricatoremails.render.events.phabricator import (
     RevisionCommentPinged,
+    RevisionRequestedChanges,
     Revision,
     ReplyContext,
     MetadataEditedReviewer,
@@ -224,6 +225,50 @@ def test_generate_phab_stamps_with_metadata_edited_reviewer():
     stamp_parts = stamps.split()
     assert len(stamp_parts) == 4
 
+
+def test_generate_phab_stamps_for_requested_changes_with_groups():
+    """Test that revision-requested-changes emits group stamps, not expanded members.
+
+    When a reviewer group is assigned, the stamp should show reviewer(#group-name)
+    rather than reviewer(@member1) reviewer(@member2) ... for each group member.
+    This allows recipients to filter on whether they were personally targeted vs.
+    targeted as a member of a group.
+    """
+    member1 = Recipient("m1@example.com", "member1", timezone.utc, False)
+    member2 = Recipient("m2@example.com", "member2", timezone.utc, False)
+
+    revision = Revision(279938, "D279938", "http://example.com/D279938", "firefox-autoland", None)
+    actor = Actor(user_name="gregtatum", real_name="Greg Tatum")
+
+    individual_reviewer = Reviewer(
+        name="bgrins",
+        is_actionable=False,
+        status=ReviewerStatus.REQUESTED_CHANGES,
+        recipients=[member1],
+    )
+    group_reviewer = Reviewer(
+        name="some-team",
+        is_actionable=False,
+        status=ReviewerStatus.UNREVIEWED,
+        recipients=[member1, member2],
+    )
+
+    event = RevisionRequestedChanges(
+        main_comment_message=None,
+        inline_comments=[],
+        transaction_link="http://example.com/tx",
+        author=None,
+        reviewers=[individual_reviewer, group_reviewer],
+        subscribers=[],
+    )
+
+    stamps = generate_phab_stamps(revision, actor, event)
+
+    assert "reviewer(@bgrins)" in stamps    # individual gets @
+    assert "reviewer(#some-team)" in stamps  # group gets #
+    # group members must NOT appear as individual reviewer stamps
+    assert "reviewer(@member1)" not in stamps
+    assert "reviewer(@member2)" not in stamps
 
 def test_generate_phab_stamps_with_regular_reviewer():
     """Test that generate_phab_stamps handles regular Reviewer objects correctly.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -107,10 +107,17 @@ def test_integration_pipeline():
                             "body": {
                                 "reviewers": [
                                     {
-                                        "username": "5",
-                                        "email": "5@mail",
-                                        "timezoneOffset": 0,
-                                        "isActor": False,
+                                        "name": "5",
+                                        "isActionable": True,
+                                        "status": "requested-changes",
+                                        "recipients": [
+                                            {
+                                                "timezoneOffset": 0,
+                                                "username": "5",
+                                                "email": "5@mail",
+                                                "isActor": False,
+                                            }
+                                        ],
                                     }
                                 ],
                                 "subscribers": [],

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,36 +40,31 @@ def test_parse_logger():
 
 
 def test_parse_file_pipeline():
-    config = _config_parser(
-        """
+    config = _config_parser("""
     [dev]
     file=example.json
-    """
-    )
+    """)
     source, worker = _parse_pipeline(config, Mock(), True)
     assert isinstance(source, FileSource)
     assert isinstance(worker, RunOnceWorker)
 
 
 def test_parse_run_once_pipeline():
-    config = _config_parser(
-        """
+    config = _config_parser("""
     [phabricator]
     host=http://phabricator.test
     token=token
 
     [dev]
     since_key=10
-    """
-    )
+    """)
     source, worker = _parse_pipeline(config, Mock(), True)
     assert isinstance(source, PhabricatorSource)
     assert isinstance(worker, RunOnceWorker)
 
 
 def test_parse_production_pipeline():
-    config = _config_parser(
-        """
+    config = _config_parser("""
     [phabricator]
     host=http://phabricator.test
     token=token
@@ -77,8 +72,7 @@ def test_parse_production_pipeline():
 
     [dev]
     story_limit=10
-    """
-    )
+    """)
     source, worker = _parse_pipeline(config, Mock(), True)
     assert isinstance(source, PhabricatorSource)
     assert isinstance(worker, PhabricatorWorker)
@@ -88,14 +82,12 @@ def test_parse_production_pipeline():
 # want to worry about in this test
 @mock.patch("phabricatoremails.mail.boto3.client")
 def test_parse_ses_mail(mock_boto3_client):
-    config = _config_parser(
-        """
+    config = _config_parser("""
     [email]
     from_address=from@mail
     implementation=ses
     [email-ses]
-    """
-    )
+    """)
     mail = _parse_mail(config, Mock())
     assert isinstance(mail, SesMail)
 
@@ -104,36 +96,31 @@ def test_parse_ses_mail(mock_boto3_client):
 # which isn't wanted in these tests, so the constructor is mocked out here.
 @mock.patch("phabricatoremails.settings.smtplib.SMTP")
 def test_parse_smtp_mail(mock_smtp):
-    config = _config_parser(
-        """
+    config = _config_parser("""
     [email]
     from_address=from@mail
     implementation=smtp
     [email-smtp]
     host=smtp-host
-    """
-    )
+    """)
     mail = _parse_mail(config, Mock())
     assert isinstance(mail, SmtpMail)
 
 
 def test_parse_fs_mail(tmp_path):
-    config = _config_parser(
-        """
+    config = _config_parser("""
     [email]
     from_address=from@mail
     implementation=fs
     [email-fs]
     "output_path={tmp_path}
-    """
-    )
+    """)
     mail = _parse_mail(config, logging.create_dev_logger())
     assert isinstance(mail, FsMail)
 
 
 def test_settings():
-    config = _config_parser(
-        """
+    config = _config_parser("""
     [phabricator]
     host=phabricator.host
 
@@ -145,19 +132,16 @@ def test_settings():
 
     [db]
     url=postgres://db
-    """
-    )
+    """)
     settings = IniSettings(config)
     assert settings.phabricator_host == "phabricator.host"
     assert settings.bugzilla_host == "bugzilla.host"
 
 
 def test_settings_missing_property_throws_error():
-    config = _config_parser(
-        """
+    config = _config_parser("""
         [db]
         url=postgres://db
-        """
-    )
+        """)
     with pytest.raises(configparser.Error):
         IniSettings(config)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -108,12 +108,12 @@ def test_parse_smtp_mail(mock_smtp):
 
 
 def test_parse_fs_mail(tmp_path):
-    config = _config_parser("""
+    config = _config_parser(f"""
     [email]
     from_address=from@mail
     implementation=fs
     [email-fs]
-    "output_path={tmp_path}
+    output_path={tmp_path}
     """)
     mail = _parse_mail(config, logging.create_dev_logger())
     assert isinstance(mail, FsMail)


### PR DESCRIPTION
## What's wrong

The `X-Phabricator-Stamps` header is embedded in emails so that mail clients can filter on events like the actor who triggered the action and who the reviewers are. For reviewer stamps, Phabricator uses a `@username` prefix for individual reviewers and a `#groupname` prefix for reviewer groups.

When a reviewer is a **group** (e.g. `#android-reviewers`), the expected stamp is a single `reviewer(#android-reviewers)`. Instead, users were seeing every individual member of the group emitted as separate stamps — e.g. `reviewer(@member1) reviewer(@member2) … reviewer(@member40)` — making email filtering rules effectively useless.

## Root cause

The Phabricator feed JSON delivers reviewers in two different shapes:

- **`Recipient`** — a flat object `{username, email, timezoneOffset, isActor}` representing a single person
- **`Reviewer`** — a richer object `{name, isActionable, status, recipients: [...]}` that can represent either an individual or a named group (with the individual members nested inside `recipients`)

The stamp-generation code checks whether a reviewer object is a `Reviewer` instance to decide whether to use `@` (individual) or `#` (group). However, six event classes — `RevisionAbandoned`, `RevisionAccepted`, `RevisionCommented`, `RevisionClosed`, `RevisionLanded`, and `RevisionRequestedChanges` (and their secure variants) — were mistakenly parsing the `reviewers` field with `Recipient.parse_many()` instead of `Reviewer.parse_many()`.

As a result, the `isinstance(r, Reviewer)` check always fell through to the `else` branch, which treated each object as a plain individual and emitted every member of a group as a separate `@username` stamp.

## Fix

Changed `Recipient.parse_many(body["reviewers"])` → `Reviewer.parse_many(body["reviewers"])` for all affected event classes. No logic changes were needed — the stamp-generation logic already handled groups correctly once given the right type.

## Related

A companion change to Phabricator itself is being tracked in [mozilla-conduit/phabricator#78](https://github.com/mozilla-conduit/phabricator/pull/78).